### PR TITLE
Simplify client threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ a web-browser. This means they can be used on a headless device such as you migh
 have connected to a hi-fi. Still, there are some usable bits:
 
 ## swimpd - Music Player Daemon server for BBC radio 
-This is MPD server written in Prolog, which provides streaming access to all
+This is an MPD server written in Prolog, which provides streaming access to all
 the programmes in the current BBC radio schedules, as well as the live radio 
 streams. Audio is handled using GStreamer, via a slave process written in Python.
-Work in progress, but works ok with mpc and ncmpc, okish with ncmpcpp, not so good 
-with Theremin and not at all with MPDroid.
+Work in progress, but works pretty well with clients mpc, ncmpc, MPDroid and M.A.L.P.
+(the latter two for Android). Not so good with Theremin, mainly because the Artist
+tag is not defined for any programme.
 
 ## bbc.py - Python script to get media stream URL from programme id
 

--- a/prolog/swimpd/gst.pl
+++ b/prolog/swimpd/gst.pl
@@ -47,9 +47,9 @@ gst_message(format, [], [format-just(Rate:Fmt:Ch)]) --> " ", split_on_colon([nat
 sample_fmt(f) --> "F", !, arb.
 sample_fmt(N) --> [_], nat(N), ([]; any(`LB_`), arb).
 
-set_volume(V) :- FV is (V/100.0)^1.75, send(fmt('volume ~5f', [FV])).
-gst_uri(URI) :- send(fmt('uri ~s',[URI])).
-send(P) :- gst(_,In), phrase(P, Codes), debug(mpd(gst), '<~~ ~s', [Codes]), format(In, '~s\n', [Codes]).
+set_volume(V) :- FV is (V/100.0)^1.75, send(fmt("volume ~5f", [FV])).
+gst_uri(URI) :- send(fmt("uri ~s",[URI])).
+send(P) :- gst(_,In), phrase(P, Codes), debug(mpd(gst), '<~~ ~s', [Codes]), format(In, "~s\n", [Codes]).
 recv(K, MV) :- gst(Id, _), (thread_get_message(Id, K-V, [timeout(3)]) -> MV = just(V); MV = nothing).
 
 start_gst_thread(V) :- spawn(with_gst(gst_reader_thread(V), _)).

--- a/prolog/swimpd/protocol.pl
+++ b/prolog/swimpd/protocol.pl
@@ -1,113 +1,108 @@
-:- module(mpd_protocol, [mpd_interactor/0, execute/2, notify_all/1]).
+:- module(mpd_protocol, [mpd_interactor/0, execute/3, notify_all/1]).
 
 :- use_module(library(insist), [insist/1]).
 :- use_module(library(dcg_core), [seqmap_with_sep//3]).
-:- use_module(tools,  [in/2, quoted//2, atom//1, report//2, parse_head//2, registered/2, thread/2]).
+:- use_module(library(dcg_pair)).
+:- use_module(tools, [in/2, quoted//2, atom//1, report//2, parse_head//2, registered/2, thread/2]).
 
 :- multifile command//2.
 
 %! mpd_interactor is det.
 % Run MPD client interaction using the current input and output Prolog streams.
-mpd_interactor :- writeln('OK MPD 0.20.0'), set_timeout(240), registered(client, wait_for_input).
-wait_for_input :- read_command(Cmd), !, handle(Cmd).
-set_timeout(T) :- current_input(In), set_stream(In, timeout(T)).
+mpd_interactor :-
+   writeln('OK MPD 0.20.0'), thread_self(Self),
+   setup_call_cleanup(thread_create(client, Id, [at_exit(thread_signal(Id, throw(kill)))]),
+                      transduce(Id), cleanup_client(Id)).
+
+client :- catch(registered(client, normal_wait([])), Ex, print_message(error, Ex)).
+cleanup_client(Id) :- catch(thread_send_message(Id, eos), _, true), thread_join(Id, _).
+transduce(Q)       :- read_command(Cmd), handle_cmd(Cmd, Q).
+handle_cmd(cmd(Head, Tail), Q) :- thread_send_message(Q, cmd(Head, Tail)), transduce(Q).
+handle_cmd(eos, _).
 
 read_command(Cmd) :-
    read_line_to_codes(current_input, Codes),
-   debug(mpd(command), ">> ~s", [Codes]),
+   debug(mpd(command), ">> `~s`", [Codes]),
    (  Codes = end_of_file -> Cmd = eos
    ;  insist(parse_head(Head, Tail, Codes, [])), Cmd = cmd(Head,Tail)
    ).
 
-handle(eos) :- !.
-handle(cmd(Head,Tail)) :- handle(Head, Tail).
+get_message(M) :- thread_self(Self), thread_get_message(Self, M, [timeout(120)]).
+normal_wait(Pending) :- get_message(M), normal_msg(M, Pending).
+normal_msg(changed(S), Pending) :- normal_wait([S|Pending]).
+normal_msg(cmd(Head, Tail), Pending) :- handle(Head, Tail, Pending).
+normal_msg(eos, _).
 
-handle(close, []) :- !.
-handle(noidle, []) :- wait_for_input.
-handle(idle, Tail) :- !,
+handle(close,  [], _) :- !.
+handle(command_list_ok_begin, [], Pending) :- !, command_list(list_ok, Pending).
+handle(command_list_begin, [], Pending)    :- !, command_list(silent, Pending).
+handle(noidle, [], Pending) :- !, normal_wait(Pending).
+handle(idle, Tail, Pending) :- !,
    once(phrase(idle_filter(Filter), Tail)),
-   thread_self(Self), current_output(Out), set_timeout(infinite),
-   setup_call_cleanup(thread_create(with_output_to(Out, listener(Self-Filter, [])), Id, []),
-                      read_command(Cmd), cleanup_listener(Cmd, Self, Id)),
-   handle(Cmd).
-handle(Head, Tail) :-
-   insist(catch((execute(Head, Tail), Reply=ok), mpd_ack(Ack), Reply=Ack)),
-   reply(Reply), wait_for_input.
-
-execute(command_list_ok_begin, []) :- !,  command_list(list_ok).
-execute(command_list_begin, []) :- !, command_list(silent).
-execute(make, []) :- !, make.
-execute(Cmd, T) :- execute1(0-'', Cmd, T).
+   idle(Pending, Filter).
+handle(Head, Tail, Pending) :- do_and_cont(execute(0-'', Head, Tail), Pending).
 
 idle_filter(nonvar) --> [].
 idle_filter(in(Subsystems)) --> " ", seqmap_with_sep(" ", quoted(atom), Subsystems).
 
-execute1(Ref, Cmd, T) :-
-   (  catch(reply_phrase(command(Cmd, T)), mpd_err(Err), throw(mpd_ack(ack(Ref, Err)))) -> true
-   ;  throw(mpd_ack(ack(Ref, err(99, 'Failed on ~s', [Cmd]))))
-   ).
+% --- command lists ---
+command_list(SubReply, Pending1) :-
+   accum(Commands-Pending2, []-Pending1),
+   do_and_cont(execute_list(Commands, 0, SubReply), Pending2).
+
+execute_list([], _, _).
+execute_list([Head-Tail|Cmds], Pos, Reply) :-
+   execute(Pos-Head, Head, Tail),
+   sub_reply(Reply), succ(Pos, Pos1),
+   execute_list(Cmds, Pos1, Reply).
+
+accum --> {get_message(Msg)}, accum_msg(Msg).
+accum_msg(changed(S)) --> \> [S], accum.
+accum_msg(cmd(Head,Tail)) --> accum_cont(Head, Tail).
+accum_cont(command_list_begin, _) --> {throw(protocol_fail)}.
+accum_cont(command_list_ok_begin, _) --> {throw(protocol_fail)}.
+accum_cont(command_list_end, []) --> !, [].
+accum_cont(Head, Tail) --> \< [Head-Tail], accum.
+
+sub_reply(silent).
+sub_reply(list_ok) :- fmt_reply('list_OK', []).
 
 reply_phrase(P) :-
    phrase(P, Codes), format('~s', [Codes]),
    debug(mpd(reply), '<< ~s|', [Codes]).
-
-command_list(Reply) :- accum(Commands, []), execute_list(Reply, Commands, 0).
-execute_list(_, [], _).
-execute_list(Reply, [Head-Tail|Cmds], Pos) :-
-   execute1(Pos-Head, Head, Tail),
-   sub_reply(Reply), succ(Pos, Pos1),
-   execute_list(Reply, Cmds, Pos1).
-
-sub_reply(silent).
-sub_reply(list_ok) :- fmt_reply('list_OK', []).
 
 reply(ok) :- fmt_reply('OK', []).
 reply(ack(Pos-SubCmd, err(Code, Fmt, Args))) :-
    fmt_reply('ACK [~d@~d] {~s} ~@', [Code, Pos, SubCmd, format(Fmt, Args)]).
 
 fmt_reply(Fmt, Args) :-
-   format(string(R), Fmt, Args),
-   debug(mpd(command), '<< ~s', [R]),
-   format('~s\n', [R]).
+   debug(mpd(reply), '~@', format(Fmt, Args)),
+   format(Fmt, Args), nl.
 
-accum --> {read_command(cmd(Head,Tail))}, accum_cont(Head, Tail).
-accum_cont(command_list_begin, _) --> {throw(protocol_fail)}.
-accum_cont(command_list_ok_begin, _) --> {throw(protocol_fail)}.
-accum_cont(command_list_end, []) --> !, [].
-accum_cont(Head, Tail) --> [Head-Tail], accum.
+% -- command execution --
+do_and_cont(G, Pending) :-
+   insist(catch((G, Reply=ok), mpd_ack(Ack), Reply=Ack)),
+   reply(Reply), normal_wait(Pending).
 
-% -- notification system ---
-listener(Id-Filter, ToPutBack) :-
-   thread_get_message(Id, Msg),
-   message_queue_property(Id, size(N)), length(Msgs, N),
-   maplist(thread_get_message(Id), Msgs),
-   listener_msg(Msg, Msgs, Id-Filter, []-ToPutBack).
-
-listener_msg(eos, _, _, _).
-listener_msg(cmd(noidle,[]), Msgs, Id-_, ToReport-ToPutBack) :-
-   report_changes(ToReport),
-   maplist(thread_send_message(Id), Msgs),
-   maplist(notify(Id), ToPutBack).
-listener_msg(changed(S), Msgs, E, ToReport-ToPutBack) :-
-   (  E = _-Filter, call(Filter, S)
-   -> listener_msgs(Msgs, E, [S|ToReport]-ToPutBack)
-   ;  listener_msgs(Msgs, E, ToReport-[S|ToPutBack])
+execute(Ref, Cmd, T) :-
+   (  catch(reply_phrase(command(Cmd, T)), mpd_err(Err), throw(mpd_ack(ack(Ref, Err)))) -> true
+   ;  throw(mpd_ack(ack(Ref, err(99, 'Failed on ~s', [Cmd]))))
    ).
 
-listener_msgs([Msg|Msgs], E, S) :- listener_msg(Msg, Msgs, E, S).
-listener_msgs([], E, []-ToPutBack) :- !, listener(E, ToPutBack).
-listener_msgs([], Id-_, ToReport-ToPutBack) :- report_changes(ToReport), listener_tail_wait(Id, ToPutBack).
+% -- notification system ---
+idle(Pending, Filter) :-
+   partition(Filter, Pending, ToReport, ToIgnore),
+   (  ToReport=[] -> idle_wait(Filter, ToIgnore)
+   ;  report_changes(ToReport), normal_wait(ToIgnore)
+   ).
 
-listener_tail_wait(Id, ToPutBack) :- thread_get_message(Id, Msg), listener_tail_msg(Msg, Id, ToPutBack).
-
-listener_tail_msg(changed(S), Id, ToPutBack) :- listener_tail_wait(Id, [S|ToPutBack]).
-listener_tail_msg(cmd(_,_), Id, ToPutBack) :- maplist(notify(Id), ToPutBack).
-
-cleanup_listener(Cmd, Self, Id) :-
-   set_timeout(240),
-   (var(Cmd) -> Cmd = eos; true),
-   thread_send_message(Self, Cmd),
-   insist(thread_join(Id, true)).
+idle_wait(Filter, ToIgnore) :- thread_get_message(Msg), idle_msg(Msg, Filter, ToIgnore).
+idle_msg(eos, _, _).
+idle_msg(cmd(noidle,[]), _, ToIgnore) :- reply(ok), normal_wait(ToIgnore).
+idle_msg(changed(S), Filter, ToIgnore) :-
+   (  call(Filter, S) -> report_changes([S]), normal_wait(ToIgnore)
+   ;  idle_wait(Filter, [S|ToIgnore])
+   ).
 
 report_changes(L) :- sort(L, L1), reply_phrase(foldl(report(changed), L1)), reply(ok).
 notify_all(Subsystems) :- forall(thread(client, Id), maplist(notify(Id), Subsystems)).

--- a/prolog/swimpd/protocol.pl
+++ b/prolog/swimpd/protocol.pl
@@ -15,7 +15,7 @@ mpd_interactor :-
                       transduce(Id), cleanup_client(Id)).
 
 client :- registered(client, normal_wait([])).
-cleanup_client(Id) :- catch(thread_send_message(Id, kill), _, true), thread_join(Id).
+cleanup_client(Id) :- catch(thread_send_message(Id, kill), _, true), thread_join(Id, _).
 transduce(Q)       :- read_command(Cmd), thread_send_message(Q, Cmd), transduce(Q).
 
 read_command(cmd(Head, Tail)) :-

--- a/swimpd
+++ b/swimpd
@@ -2,6 +2,8 @@
 user:file_search_path(python, 'python').
 user:file_search_path(bbc, 'prolog').
 
+:- use_module(library(apply_macros)).
+:- use_module(library(dcg_macros)). % NB. import into user means these apply globally
 :- use_module(prolog/swimpd/telnetd,  [telnet_server/3]).
 :- use_module(prolog/swimpd/protocol, [mpd_interactor/0]).
 :- use_module(prolog/swimpd/gst,      [start_gst_thread/1]).


### PR DESCRIPTION
This PR replaces the working but horrible implementation of the `idle` command that spawned a new thread to process `change` messages while the main client thread waits for the next command from the client with cleaner implementation consisting of two long-lived threads per client: one whose only job is to translate command strings read from the client into structured messages sent to the other thread, while the other thread implements the whole state machine for one client including the twisted idle logic. This results in a good 35% reduction in CPU usage when using ncmpc, which continually sends idle, noidle, and status messages while playing.

The other part of the PR is some further optimisations, some probably futile, but some (in conjunction with a newly optimised break//1 in the pack dcgutils) moderately effective in reducing the computational cost of parsing commands.