### PR TITLE
Work around io watch problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ropeproject/
 .*.sw[n-p]
 .swipl_history
+state*.pl

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ropeproject/
+.*.sw[n-p]

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .*.sw[n-p]
 .swipl_history
 state*.pl
+*.pyc
+.pyhistory

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ropeproject/
 .*.sw[n-p]
+.swipl_history

--- a/prolog/swimpd/gst.pl
+++ b/prolog/swimpd/gst.pl
@@ -27,9 +27,9 @@ gst_reader_thread(V, _-(In-Out)) :-
 
 gst_reader(V, Self, Out) :- set_volume(V), gst_read_next(Self, Out).
 gst_read_next(Self, Out) :- read_line_to_codes(Out, Codes), gst_handle(Codes, Self, Out).
-gst_handle(end_of_file, _, _) :- debug(mpd(gst), 'End of stream from gst', []).
+gst_handle(end_of_file, _, _).
 gst_handle(Codes, Self, Out) :-
-   debug(mpd(gst), '~~> ~s', [Codes]),
+   debug(gst(io), '~~> ~s', [Codes]),
    insist(phrase(parse_head(Head, Tail), Codes)),
    (  phrase(gst_message(Head, Msgs, Globals), Tail)
    -> maplist(thread_send_message(Self), Msgs),
@@ -49,9 +49,9 @@ sample_fmt(N) --> [_], nat(N), ([]; any(`LB_`), arb).
 
 set_volume(V) :- FV is (V/100.0)^1.75, send(fmt("volume ~5f", [FV])).
 gst_uri(URI) :- send(fmt("uri ~s",[URI])).
-send(P) :- gst(_,In), phrase(P, Codes), debug(mpd(gst), '<~~ ~s', [Codes]), format(In, "~s\n", [Codes]).
-recv(K, MV) :- gst(Id, _), ( thread_get_message(Id, K-V, [timeout(3)]) -> MV = just(V)
-                           ; debug(mpd(gst), 'WARNING: timeout waiting for ~w', [K]), MV = nothing).
+send(P) :- gst(_,In), phrase(P, Codes), debug(gst(io), '<~~ ~s', [Codes]), format(In, "~s\n", [Codes]).
+recv(K, MV) :- gst(Id, _), ( thread_get_message(Id, K-V, [timeout(10)]) -> MV = just(V)
+                           ; print_message(warning, recv_timeout(K)), MV = nothing).
 
 start_gst_thread(V) :- spawn(with_gst(gst_reader_thread(V), _)).
 

--- a/prolog/swimpd/gst.pl
+++ b/prolog/swimpd/gst.pl
@@ -27,9 +27,9 @@ gst_reader_thread(_-(In-Out)) :-
 
 gst_reader(Self, Out) :- state(volume, V), set_volume(V), gst_read_next(Self, Out).
 gst_read_next(Self, Out) :- read_line_to_codes(Out, Codes), gst_handle(Codes, Self, Out).
-gst_handle(end_of_file, _, _) :- !, debug(mpd(gst), 'End of stream from gst', []).
+gst_handle(end_of_file, _, _) :- !, debug(gst, 'End of stream from gst', []).
 gst_handle(Codes, Self, Out) :-
-   debug(gst(io), '~~> ~s', [Codes]),
+   debug(gst, '~~> ~s', [Codes]),
    insist(phrase(parse_head(Head, Tail), Codes)),
    (  phrase(gst_message(Head, Msgs, Globals), Tail)
    -> maplist(thread_send_message(Self), Msgs),
@@ -49,7 +49,7 @@ sample_fmt(N) --> [_], nat(N), ([]; any(`LB_`), arb).
 
 set_volume(V) :- FV is (V/100.0)^1.75, send(fmt("volume ~5f", [FV])).
 gst_uri(URI) :- send(fmt("uri ~s",[URI])).
-send(P) :- gst(_,In), phrase(P, Codes), debug(gst(io), '<~~ ~s', [Codes]), format(In, "~s\n", [Codes]).
+send(P) :- gst(_,In), phrase(P, Codes), debug(gst, '<~~ ~s', [Codes]), format(In, "~s\n", [Codes]).
 recv(K, MV) :- gst(Id, _), ( thread_get_message(Id, K-V, [timeout(10)]) -> MV = just(V)
                            ; print_message(warning, recv_timeout(K)), MV = nothing).
 


### PR DESCRIPTION
This PR addresses a problem with using the GLib main loop to multiplex messages from GStreamer with input on stdin. For some reason, the GLib IO watch thing was sometimes not responding input available on stdin even though it had definitely been flushed from the Prolog end. This happened quite consistently when starting to a play a new stream, resulting in a receive timeout on the Prolog side, as it waited for a response to the 'position' message. To solve this, I have abandoned the GLib main loop and gone for two threads: one reading from stdin and the other reading messages from GStreamer. The only synchronisation required is a mutex lock on writing to stdout.