### PR TITLE
Support album artist views

### DIFF
--- a/prolog/TODO
+++ b/prolog/TODO
@@ -1,0 +1,21 @@
+   Core
+      seek, CLP approach?
+      lightweight threads
+
+   Control
+      auto next as well as single (handle stored position correctly too)
+      rewind if playing track where current position is at end
+      Better seekable timeline for radio streams
+      Stop GST player after some time to release audio device
+
+   State management:
+      multiple sessions
+      persistence
+
+   Protocol:
+      clearerror (check error in status?) consume, single, mutliple group
+
+   database
+      subfolders by week
+      Shelf for keeping programmes
+      more efficient artist-album-track database view

--- a/prolog/bbc_db.pl
+++ b/prolog/bbc_db.pl
@@ -24,7 +24,7 @@ xpath_attr_time(E, Path, A, ts(Time)) :- xpath(E, Path, E1), xpath(E1, /self(@A)
 with_url(URL, Stream, Goal) :- setup_call_cleanup(http_open(URL, Stream, []), Goal, close(Stream)).
 get_as(json, URL, Dict) :- with_url(URL, In, json_read_dict(In, Dict)).
 get_as(xml, URL, DOM)   :- with_url(URL, In, load_xml(In, DOM, [space(remove)])).
-get_as(html, URL, DOM)  :- with_url(URL, In, load_html(In, DOM, [space(strict), cdata(string)])).
+get_as(html, URL, DOM)  :- with_url(URL, In, load_html(In, DOM, [space(preserve), cdata(string)])).
 get_as(pls, URL, Codes) :- with_url(URL, In, read_file_to_codes(In, Codes, [])).
 uget(Head, Result) :-
    call(Head, Fmt, Pattern-Args),

--- a/prolog/bbc_db.pl
+++ b/prolog/bbc_db.pl
@@ -114,7 +114,7 @@ entry_vpid(E, X) :- entry_prop(E, vpid(X)).
 entry_vpid(E, X) :- entry_prop(E, pid(PID)), pid_version(PID, V), version_prop(V, vpid(X)).
 
 entry_xurl(Method, E, XURL) :- prog_xurl(Method, entry(E), XURL).
-prog_xurl(redir(Fmt), entry(E), inf-HREF) :- entry_prop(E, link(Fmt, HREF)).
+prog_xurl(redir(Fmt), entry(E), inf-HREF) :- \+entry_prop(E, vpid('')), entry_prop(E, link(Fmt, HREF)).
 prog_xurl(best(Fmt), Prog, XURL) :-
    aggregate(max(B, XUs), setof(XU, prog_fmt_bitrate_xurl(Prog, Fmt, B, XU), XUs), max(_, XURLs)),
    member(XURL, XURLs).

--- a/prolog/bbc_db.pl
+++ b/prolog/bbc_db.pl
@@ -1,5 +1,5 @@
-:- module(bbc_db, [service/1, service/3, fetch_new_schedule/1, service_schedule/2, service_live_url/2,
-                   service_entry/2, schedule_updated/2, pid_entry/3, entry_prop/2, entry_xurl/3, prog_xurl/3,
+:- module(bbc_db, [service/1, service/2, service_updated/2, fetch_new_schedule/1, service_live_url/2,
+                   service_entry/2, pid_entry/3, entry_prop/2, entry_xurl/3, prog_xurl/3,
                    interval_times/3, entry_maybe_parent/3, entry_parents/2, pid_version/2, version_prop/2]).
 
 :- use_module(library(sgml)).
@@ -17,10 +17,8 @@
 :- dynamic snapshot_time_service/2, time_service_schedule/3.
 
 interval_times(ts(S)-ts(E), S, E).
-in_interval(ts(A)-ts(B), X) :- A =< X, X =< B.
-xpath_interval(As, E, Path, T1-T2) :- maplist(xpath_attr_time(E, Path), As, [T1, T2]).
-xpath_attr_time(E, Path, A, ts(Time)) :- xpath(E, Path, E1), xpath(E1, /self(@A), T), parse_time(T, iso_8601, Time).
 
+% --- URL and HTTP tools ----
 with_url(URL, Stream, Goal) :- setup_call_cleanup(http_open(URL, Stream, []), Goal, close(Stream)).
 get_as(json, URL, Dict) :- with_url(URL, In, json_read_dict(In, Dict)).
 get_as(xml, URL, DOM)   :- with_url(URL, In, load_xml(In, DOM, [space(remove)])).
@@ -31,38 +29,19 @@ uget(Head, Result) :-
    format(string(URL), Pattern, Args),
    get_as(Fmt, URL, Result).
 
+% --- service database
 service(S) :- service(S, _, _).
-service(bbc_radio_one,   'R1', 'BBC Radio 1').
-service(bbc_radio_two,   'R2', 'BBC Radio 2').
-service(bbc_radio_three, 'R3', 'BBC Radio 3').
-service(bbc_radio_fourfm,'R4', 'BBC Radio 4 FM').
-service(bbc_radio_four_extra, 'R4X', 'BBC Radio 4 Extra').
-service(bbc_6music,      '6Music', 'BBC 6 Music').
-service(bbc_world_service, 'World', 'BBC World Service').
+service(S, ServiceName) :- service(S, _, ServiceName).
 
-service_live_url(S, URL) :-
-   service(S, _, _),
-   format(string(URL), 'http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/dash/uk/dash_full/ak/~s.mpd', [S]).
+service(p00fzl86, bbc_radio_one,        'BBC Radio 1').
+service(p00fzl8v, bbc_radio_two,        'BBC Radio 2').
+service(p00fzl8t, bbc_radio_three,      'BBC Radio 3').
+service(p00fzl7j, bbc_radio_fourfm,     'BBC Radio 4 FM').
+service(p00fzl7l, bbc_radio_four_extra, 'BBC Radio 4 Extra').
+service(p00fzl65, bbc_6music,           'BBC 6 Music').
+service(p00fzl9p, bbc_world_service,    'BBC World Service').
 
-mediaset_format(F) :- member(F, [json, xml, pls]).
-mediaset_type(aod, MS) :- member(MS, ['pc', 'audio-syndication', 'audio-syndication-dash', 'apple-ipad-hls', 'iptv-all']).
-mediaset_type(live_only, MS) :- member(MS, ['apple-icy-mp3a', 'http-icy-aac-lc-a']).
-
-service_pid(bbc_radio_one,        p00fzl86).
-service_pid(bbc_radio_two,        p00fzl8v).
-service_pid(bbc_radio_three,      p00fzl8t).
-service_pid(bbc_radio_fourfm,     p00fzl7j).
-service_pid(bbc_radio_four_extra, p00fzl7l).
-service_pid(bbc_6music,           p00fzl65).
-service_pid(bbc_world_service,    p00fzl9p).
-
-service_web_sched(Suffix, S, html, 'http://www.bbc.co.uk/schedules/~s~s'-[PID, Suffix]) :- service_pid(S, PID).
-
-service_availability(S, xml, 'http://www.bbc.co.uk/radio/aod/availability/~s.xml'-[S]) :- service(S).
-playlist(PID, json, 'http://www.bbc.co.uk/programmes/~s/playlist.json'-[PID]).
-u_mediaset(Fmt, MediaSet, VPID, Fmt, URLForm-[MediaSet, Fmt, VPID]) :-
-   URLForm = 'http://open.live.bbc.co.uk/mediaselector/6/select/version/2.0/mediaset/~s/format/~s/vpid/~s',
-   mediaset_type(_, MediaSet), mediaset_format(Fmt).
+% --- getting the schedules -------------------------------------------------
 
 fetch_new_schedule(S) :-
    get_time(Now),
@@ -71,31 +50,23 @@ fetch_new_schedule(S) :-
    assert(time_service_schedule(Now, S, Schedule)),
    assert(snapshot_time_service(Now, S)).
 
-time_to_year_week(T, YearWeek) :- format_time(atom(YearWeek), '%G/w%V', T).
-fetch_new_schedule_json(S, sched(Updated, ETree)) :-
-   service(S), get_time(Now),
-   format_time(atom(Updated), '%FT%T%z', Now),
-   LastWeek is Now - 7*24*3600,
-   maplist(time_etree(S), [Now, LastWeek], [ET1, ET2]),
-   assoc_merge(ET1, ET2, ETree).
+% -- new JSON schedule from web page
+service_web_sched(Suffix, S, html, 'http://www.bbc.co.uk/schedules/~s~s'-[S, Suffix]) :- service(S).
 
-assoc_add(K-V, A1, A2) :- put_assoc(K, A1, V, A2).
-assoc_merge(A1, A2, A3) :-
-   assoc_to_list(A1, A1List),
-   foldl(assoc_add, A1List, A2, A3).
+fetch_new_schedule_json(S, ETree) :-
+   service(S), get_time(Now), LastWeek is Now - 7*24*3600,
+   findall(E, (member(T, [Now, LastWeek]), service_time_entry(S, T, E)), Es),
+   call(ord_list_to_assoc * sort(1, @<) * maplist(pairf(entry_pid)), Es, ETree).
 
-time_etree(S, Time, ETree) :-
+service_time_entry(S, Time, entry(Props)) :-
    format_time(atom(YW1), '/%G/w%V', Time),
    uget(service_web_sched(YW1, S), [DOM]),
    xpath(DOM, body/div(@id='orb-modules')//script(@type='application/ld+json',content), [X]),
-   atom_json_dict(X, T, []),
-   get_dict('@graph', T, Graph),
-   findall(E, graph_entry(Graph, E), Es),
-   call(ord_list_to_assoc * sort(1, @<) * maplist(pairf(entry_pid)), Es, ETree).
+   atom_json_dict(X, T, []), get_dict('@graph', T, Graph), member(E, Graph),
+   findall(Prop, jprop(E, Prop), Props).
 
-graph_entry(Graph, entry(Props)) :- member(E, Graph), findall(Prop, jprop(E, Prop), Props).
 jprop(E, pid(X))      :- string_to_atom(E.identifier, X).
-jprop(E, service(X))  :- string_to_atom(E.publication.publishedOn.name, Long), service(X, _, Long).
+jprop(E, service(X))  :- string_to_atom(E.publication.publishedOn.name, X).
 jprop(E, image(X))    :- get_dict(image, E, X).
 jprop(E, title(X))    :- X=E.name.
 jprop(E, synopsis(X)) :- X=E.description.
@@ -104,22 +75,22 @@ jprop(E, broadcast(ts(T1)-ts(T2))) :- P=E.publication, maplist(parse_time, [P.st
 jprop(E, parent(PID, 'Brand', Name)) :-
    get_dict(partOfSeries, E, P),
    string_to_atom(P.identifier, PID),
-   Name=P.name.
+   string_to_atom(P.name, Name).
 
-fetch_new_schedule_xml(S, sched(Updated, ETree)) :-
-   insist(uget(service_availability(S), [DOM])),
-   xpath(DOM, /self(@updated), Updated),
+% -- old XML feed
+service_xml_feed(S, xml,  'http://www.bbc.co.uk/radio/aod/availability/~s.xml'-[P]) :- service(S, P).
+
+fetch_new_schedule_xml(S, ETree) :-
+   insist(uget(service_xml_feed(S), [DOM])),
    findall(E, dom_entry(DOM, E), Es),
    call(ord_list_to_assoc * sort(1, @<) * maplist(pairf(entry_pid)), Es, ETree).
 
-entry_pid(E, PID) :- entry_prop(E, pid(PID)).
 dom_entry(DOM, entry(Props)) :- xpath(DOM, /schedule/entry, E), findall(Prop, prop(E, Prop), Props).
-
 prop(E, key(X))      :- xpath(E, key(text), X).
 prop(E, vpid(X))     :- xpath(E, /self(@pid), X).
 prop(E, pid(X))      :- xpath(E, pid(text), X).
 prop(E, title(X))    :- xpath(E, title(text), X).
-prop(E, service(X))  :- xpath(E, service(text), X).
+prop(E, service(X))  :- xpath(E, service(text), Y), service(_, Y, X).
 prop(E, synopsis(X)) :- xpath(E, synopsis(text), X).
 prop(E, duration(X)) :- xpath(E, broadcast(@duration), Y), atom_number(Y,X).
 prop(E, availability(X)) :- xpath_interval([start, end], E, availability, X).
@@ -127,39 +98,63 @@ prop(E, broadcast(X)) :- xpath_interval([start, end], E, broadcast, X).
 prop(E, link(F,URL)) :- xpath(E, links/link(@transferformat=F,text), URL).
 prop(E, parent(PID, Type, Name)) :-
    xpath(E, parents/parent, P),
-   maplist(xpath(P), [/self(@pid), /self(@type), /self(text)], [PID, Type, Name]).
+   maplist(xpath(P), [/self(@pid), /self(@type), /self(text)], [PID, Type, Name]). % FIXME: Name must be atom
 
+xpath_interval(As, E, Path, T1-T2) :- maplist(xpath_attr_time(E, Path), As, [T1, T2]).
+xpath_attr_time(E, Path, A, ts(Time)) :- xpath(E, Path, E1), xpath(E1, /self(@A), T), parse_time(T, iso_8601, Time).
+
+% --- schedule access -----------------
 schedule(latest(S), Schedule) :- service_schedule(S, Schedule).
 schedule(any,       Schedule) :- ordered_service_schedule(_, Schedule).
-schedule_updated(sched(Updated, _), Updated).
-service_schedule(S, Schedule) :- service(S, _, _), once(ordered_service_schedule(S, Schedule)).
+service_schedule(S, Schedule) :- service(S), once(ordered_service_schedule(S, Schedule)).
+service_updated(S, Updated) :-
+   service(S), aggregate_all(max(T), snapshot_time_service(T, S), TMax),
+   format_time(atom(Updated), '%FT%T%z', TMax).
 ordered_service_schedule(S, Sch) :- order_by([desc(T)], snapshot_time_service(T, S)), time_service_schedule(T, S, Sch).
 
+pid_entry(Mode, PID, E)  :- schedule(Mode, ETree), get_assoc(PID, ETree, E).
+service_entry(S, E) :- service_schedule(S, ETree), gen_assoc(_, ETree, E).
+
+% --- entry attributes ----------------
+entry_prop(entry(Props), Prop) :- member(Prop, Props).
+entry_pid(E, PID) :- entry_prop(E, pid(PID)).
+entry_vpid(E, X) :- entry_prop(E, vpid(X)).
+entry_vpid(E, X) :- entry_prop(E, pid(PID)), pid_version(PID, V), version_prop(V, vpid(X)).
+entry_xurl(Method, E, XURL) :- prog_xurl(Method, entry(E), XURL).
+
+entry_parents(E, SortedParents) :-
+   findall(T-N, entry_prop(E, parent(_, T, N)), Parents),
+   sort_by(parent_type_priority * fst, Parents, SortedParents).
+parent_type_priority('Brand', 1).
+parent_type_priority('Series', 2).
+
+entry_maybe_parent(T, E, just(PPID-Name)) :- entry_prop(E, parent(PPID, T, Name)), !.
+entry_maybe_parent(_, _, nothing).
+
+entry_title_contains(Sub, E) :-
+   xpath(E, title(text), T),
+   maplist(downcase_atom, [Sub, T], [SubLower, TLower]),
+   once(sub_atom(TLower, _, _, _, SubLower)).
+
+% --- versions and media streams -------------------------------
+
+service_live_url(S, URL) :-
+   service(S, P, _),
+   format(string(URL), 'http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/dash/uk/dash_full/ak/~s.mpd', [P]).
+
+playlist(PID, json, 'http://www.bbc.co.uk/programmes/~s/playlist.json'-[PID]).
 pid_version(PID, C-I) :- uget(playlist(PID), PL), member(V, PL.allAvailableVersions), C=V.smpConfig, member(I, C.items).
+
 version_prop(_-I, vpid(VPID)) :- atom_string(VPID, I.vpid).
 version_prop(_-I, duration(I.duration)).
 version_prop(C-_, title(C.title)).
 version_prop(C-_, summary(C.summary)).
-
-pid_entry(Mode, PID, E)  :- schedule(Mode, sched(_, ETree)), get_assoc(PID, ETree, E).
-service_entry(S, E) :- service_schedule(S, sched(_, ETree)), gen_assoc(_, ETree, E).
-
-title_contains(Sub, E) :-
-   xpath(E, title(text), T),
-   maplist(downcase_atom, [Sub, T], [SubLower, TLower]),
-   once(sub_atom(TLower, _, _, _, SubLower)).
 
 play_url(Player, URL) :-
    absolute_file_name(path(Player), _, [solutions(all), access(read)]),
    format(string(C), '~w "~s"', [Player, URL]),
    shell(C).
 
-entry_prop(entry(Props), Prop) :- member(Prop, Props).
-
-entry_vpid(E, X) :- entry_prop(E, vpid(X)).
-entry_vpid(E, X) :- entry_prop(E, pid(PID)), pid_version(PID, V), version_prop(V, vpid(X)).
-
-entry_xurl(Method, E, XURL) :- prog_xurl(Method, entry(E), XURL).
 prog_xurl(redir(Fmt), entry(E), inf-HREF) :- \+entry_prop(E, vpid('')), entry_prop(E, link(Fmt, HREF)).
 prog_xurl(best(Fmt), Prog, XURL) :-
    aggregate(max(B, XUs), setof(XU, prog_fmt_bitrate_xurl(Prog, Fmt, B, XU), XUs), max(_, XURLs)),
@@ -178,15 +173,15 @@ vpid_media(MST, VPID, M) :-
    member(M, MS.media).
 mediaset(Fmt, MS, VPID, Result) :- uget(u_mediaset(Fmt, MS, VPID), Result).
 
-entry_parents(E, SortedParents) :-
-   findall(T-N, entry_prop(E, parent(_, T, N)), Parents),
-   sort_by(parent_type_priority * fst, Parents, SortedParents).
-parent_type_priority('Brand', 1).
-parent_type_priority('Series', 2).
+u_mediaset(Fmt, MediaSet, VPID, Fmt, URLForm-[MediaSet, Fmt, VPID]) :-
+   URLForm = 'http://open.live.bbc.co.uk/mediaselector/6/select/version/2.0/mediaset/~s/format/~s/vpid/~s',
+   mediaset_type(_, MediaSet), mediaset_format(Fmt).
 
-entry_maybe_parent(T, E, just(PPID-Name)) :- entry_prop(E, parent(PPID, T, Name)), !.
-entry_maybe_parent(_, _, nothing).
+mediaset_format(F) :- member(F, [json, xml, pls]).
+mediaset_type(aod, MS) :- member(MS, ['pc', 'audio-syndication', 'audio-syndication-dash', 'apple-ipad-hls', 'iptv-all']).
+mediaset_type(live_only, MS) :- member(MS, ['apple-icy-mp3a', 'http-icy-aac-lc-a']).
 
+% --- term display -----
 user:portray(ts(Timestamp)) :- format_time(user_output, '<%FT%T%z>', Timestamp).
 user:portray(entry(Props)) :-
    maplist(entry_prop(entry(Props)), [pid(PID), title(Title)]),

--- a/prolog/swimpd/database.pl
+++ b/prolog/swimpd/database.pl
@@ -171,7 +171,7 @@ live_service_tags(_-SLN, [file-File, 'Title'-SLN]) :- path_file(['Live Radio', S
 entry_date(E, Date) :- entry_prop(E, broadcast(Date)).
 entry_tags(Dir, E, PID) -->
    {maplist(entry_prop(E), [pid(PID), synopsis(Syn), duration(Dur)]), path_file([Dir, PID], File)},
-	[file-File, 'Artist'-Dir, 'Comment'-Syn, duration-Dur],
+	[file-File, 'Comment'-Syn, duration-Dur],
    tag(title_and_maybe_album(Dir, PID), E),
    foldl(maybe, [tag(service, E), tag(broadcast, E), tag(availability, E)]).
 

--- a/prolog/swimpd/database.pl
+++ b/prolog/swimpd/database.pl
@@ -122,7 +122,7 @@ find(Filters, Tracks) :-
    entries_tracks(Es, Tracks).
 
 db_list(genre, [], _) --> [].
-db_list(album, [], just(GroupBy)) -->
+db_list(album, [], [GroupBy]) -->
    { service_tag(GroupBy, ServiceTag), !,
      findall(SN-Brands, artist_albums(SN, Brands), ServiceNameBrands) },
    foldl(report_service_name_brands(ServiceTag), ServiceNameBrands).
@@ -136,17 +136,17 @@ db_list(album, [ArtistTag-Artist], GroupBy) -->
      artist_albums(Artist, Albums),
      album_reporter(GroupBy, Reporter) },
    foldl(Reporter, Albums).
-db_list(albumartist, Filters, nothing) -->
+db_list(albumartist, Filters, []) -->
    { sort(Filters, [album-Album, artist-Artist]),
      service(S, Artist), once(service_brand(S, Album)) },
    report('AlbumArtist'-Artist).
-db_list(Tag, [], nothing) -->
+db_list(Tag, [], []) -->
    { service_tag(Tag, ServiceTag),
      findall(ServiceName, service(_, ServiceName), ServiceNames) },
    foldl(report(ServiceTag), ServiceNames).
 
-album_reporter(nothing, report('Album')).
-album_reporter(just(date), report_album_with('Date'-ThisYear)) :-
+album_reporter([], report('Album')).
+album_reporter([date], report_album_with('Date'-ThisYear)) :-
    get_time(Now), format_time(atom(ThisYear),'%Y',Now).
 
 service_brand(S, B) :- service_entry(S, E), entry_prop(E, parent(_, 'Brand', B, _)).

--- a/prolog/swimpd/database.pl
+++ b/prolog/swimpd/database.pl
@@ -1,4 +1,4 @@
-:- module(database, [is_programme/1, pid_id/2, id_pid/2, lsinfo//1, addid//2, db_update/1, db_stats/1, db_count//1, db_find//1, db_list//1]).
+:- module(database, [is_programme/1, pid_id/2, id_pid/2, lsinfo//1, addid//2, db_update/1, db_stats/1, db_count//1, db_find//1, db_list//3]).
 
 /* <module> BBC database interface for MPD server
 
@@ -13,24 +13,24 @@
 :- use_module(state,  [state/2, set_state/2]).
 :- use_module(tools,  [report//1, report//2, maybe/2, maybe//2, spawn/1]).
 :- use_module(bbc(bbc_tools), [sort_by/3, log_and_succeed/1]).
-:- use_module(bbc(bbc_db), [service/3, fetch_new_schedule/1, service_schedule/2, service_live_url/2, pid_entry/3,
+:- use_module(bbc(bbc_db), [service/1, service/2, fetch_new_schedule/1, service_live_url/2, pid_entry/3,
                             service_entry/2, entry_prop/2, entry_maybe_parent/3, entry_xurl/3, interval_times/3,
-                            schedule_updated/2, entry_parents/2, version_prop/2, prog_xurl/3, pid_version/2]).
+                            service_updated/2, entry_parents/2, version_prop/2, prog_xurl/3, pid_version/2]).
 
 :- volatile_memo pid_id(+atom, -integer).
 pid_id(_, Id) :- flag(songid, Id, Id+1).
 id_pid(Id,PID) :- once(browse(pid_id(PID, Id))).
-is_programme(PID) :- \+service(PID, _, _).
+is_programme(PID) :- \+service(PID).
 
 % --- update and stats ---
-db_update([]) :- forall(service(S, _, _), fetch_new_schedule(S)), set_with(db_stats, db_stats).
-db_update([ServiceName]) :- service(S, _, ServiceName), fetch_new_schedule(S), set_with(db_stats, db_stats).
+db_update([]) :- forall(service(S), fetch_new_schedule(S)), set_with(db_stats, db_stats).
+db_update([ServiceName]) :- service(S, ServiceName), fetch_new_schedule(S), set_with(db_stats, db_stats).
 db_stats(Stats) :- state(db_stats, Stats) -> true; set_with(db_stats, db_stats), db_stats(Stats). % FIXME
 set_with(K, P) :- call(P, _, V), set_state(K, V).
 
 db_stats(_, [artists-NumServices, albums-M, songs-N, db_playtime-Dur]) :-
    findall(B-D, brand_dur(B, D), Items), length(Items, N),
-   aggregate_all(count, service(_, _, _), NumServices),
+   aggregate_all(count, service(_), NumServices),
    aggregate_all(count, distinct(PP,  member(just(PP-_)-_, Items)), M),
    aggregate_all(sum(D), member(_-D, Items), DurFloat), round(DurFloat, Dur).
 brand_dur(B, D) :- service_entry(_, E), entry_maybe_parent('Brand', E, B), entry_prop(E, duration(D)).
@@ -43,7 +43,7 @@ addid(['PID', PID], just(Id)) --> {pid_id(PID, Id)}, add_pid(PID).
 addid(['Live Radio', LongName], just(Id)) --> {live_service(S, LongName), pid_id(S, Id)}, add_live(S-LongName).
 addid(['In Progress', PID], just(Id)) --> {pid_entry(any, PID, E), pid_id(PID, Id)}, add('In Progress', E).
 addid([ServiceName, PID], just(Id)) -->
-   {service(S, _, ServiceName), ensure_service_schedule(S),  pid_entry(latest(S), PID, E), pid_id(PID, Id)},
+   {service(S, ServiceName), ensure_service_schedule(S),  pid_entry(latest(S), PID, E), pid_id(PID, Id)},
    add(ServiceName, E).
 
 add_live(S-SLN) --> {live_service_tags(S-SLN, Tags), live_url(S, URL)}, [song(S, =(URL), Tags)].
@@ -57,14 +57,14 @@ version_url(V, URL) :- version_prop(V, vpid(VPID)), prog_xurl(_, vpid(VPID), _-U
 % --- query db contents ---
 lsinfo([]) -->
    foldl(report(directory), ['In Progress', 'Live Radio']),
-   {findall(S-SLN, service(S, _, SLN), Services)}, foldl(service_dir, Services).
+   {findall(S-SLN, service(S, SLN), Services)}, foldl(service_dir, Services).
 lsinfo(['Live Radio']) --> {live_services(Services)}, foldl(live_radio, Services).
 lsinfo([Dir]) --> {directory(Dir, Items)}, foldl(programme(Dir), Items).
 
 directory('In Progress', Items) :-
    findall(E, (state(position(PID), _), once(pid_entry(any, PID, E))), Items).
 directory(ServiceName, SortedItems) :-
-	service(S, _, ServiceName),
+	service(S, ServiceName),
    ensure_service_schedule(S),
    findall(E, service_entry(S, E), Items),
    sort_by(entry_sortkey, Items, SortedItems).
@@ -75,7 +75,7 @@ live_radio(S-ServiceName) -->
    foldl(report, Tags), report('Id'-Id).
 
 service_dir(S-Name) --> report(directory-Name), maybe(service_updated(S)).
-service_updated(S) --> {service_schedule(S, Sch), schedule_updated(Sch, Updated)}, report('Last-Modified'-Updated).
+service_updated(S) --> {service_updated(S, Updated)}, report('Last-Modified'-Updated).
 
 programme(Dir, E) -->
 	{insist(entry_tags(Dir, E, PID, Tags, [])), pid_id(PID, Id)},
@@ -87,71 +87,66 @@ service_tag(albumartist, 'AlbumArtist').
 
 db_find(Filters) --> {find(Filters, Tracks)}, foldl(found_track, Tracks).
 db_count(Filters) -->
-   {find(Filters, Tracks),
-    length(Tracks, NumTracks),
-    aggregate_all(sum(D), (member(_-E, Tracks), entry_prop(E, duration(D))), TotalDur),
-    round(TotalDur, IntDur)
+   { find(Filters, Tracks),
+     length(Tracks, NumTracks),
+     aggregate_all(sum(D), (member(_-E, Tracks), entry_prop(E, duration(D))), TotalDur),
+     round(TotalDur, IntDur)
    },
    foldl(report, [songs-NumTracks, playtime-IntDur]).
 
 found_track(TrackNo-E) -->
-	{entry_prop(E, service(S)),
-    service(S, _, Dir),
-    insist(entry_tags(Dir, E, _PID, Tags, []))
-   }, % pid_id(PID, Id)},
+	{ entry_prop(E, service(ServiceName)),
+     insist(entry_tags(ServiceName, E, _PID, Tags, []))
+   },
 	foldl(report, Tags), report('Track'-TrackNo).
 
 find(Filters, [Track]) :-
-   sort(Filters, [album-AlbumCodes, ArtistTag-ArtistCodes, track-TrackCodes]),
-   find([album-AlbumCodes, ArtistTag-ArtistCodes], Tracks),
-   number_codes(TrackNo, TrackCodes), nth1(TrackNo, Tracks, Track).
+   select(track-TrackAtom, Filters, FiltersRem), atom_number(TrackAtom, TrackNo),
+   find(FiltersRem, Tracks), nth1(TrackNo, Tracks, Track).
 find(Filters, Tracks) :-
-   sort(Filters, [album-AlbumCodes, ArtistTag-ArtistCodes]),
-   service_tag(ArtistTag, _),
-   atom_codes(Artist, ArtistCodes), string_codes(Album, AlbumCodes),
-   service(S, _, Artist),
+   sort(Filters, [album-Album]),
+   service_album_tracks(_, Album, Tracks).
+find(Filters, Tracks) :-
+   sort(Filters, [album-Album, ArtistTag-Artist]),
+   service_tag(ArtistTag, _), service(S, Artist),
+   service_album_tracks(S, Album, Tracks).
+find(Filters, Tracks) :-
+   sort(Filters, [ArtistTag-Artist]),
+   service_tag(ArtistTag, _), service(S, Artist),
+   service_tracks(S, Tracks).
+
+service_album_tracks(S, Album, Tracks) :-
    findall(E, (service_entry(S, E), entry_prop(E, parent(_, _, Album))), Es),
    sort_by(entry_date, Es, SortedEntries),
    enumerate(SortedEntries, Tracks).
-find(Filters, Tracks) :-
-   sort(Filters, [album-AlbumCodes]),
-   string_codes(Album, AlbumCodes),
-   findall(E, (service_entry(_, E), entry_prop(E, parent(_, _, Album))), Es),
+service_tracks(S, Tracks) :-
+   findall(E, service_entry(S, E), Es),
    sort_by(entry_date, Es, SortedEntries),
    enumerate(SortedEntries, Tracks).
 
-entry_date(E, Date) :- entry_prop(E, broadcast(Date)).
 
-
-db_list(list(Tag, Filters, GroupBy)) --> db_list_new(Tag, Filters, GroupBy).
-db_list(albums_by_artist(Artist)) --> {artist_albums(Artist, Albums)}, foldl(report('Album'), Albums).
-
-db_list_new(genre, [], _) --> [].
-db_list_new(album, [], nothing) -->
-   {setof(B, S^service_brand(S, B), Brands)},
-   foldl(report('Album'), Brands).
-db_list_new(album, [], just(date)) -->
-   {album_reporter(just(date), Reporter),
-    setof(B, service_brand(_, B), Brands)},
-   foldl(Reporter, Brands).
-db_list_new(album, [], just(GroupBy)) -->
-   {service_tag(GroupBy, ServiceTag)},
-   {findall(SN-Brands, artist_albums(SN, Brands), ServiceNameBrands)},
+db_list(genre, [], _) --> [].
+db_list(album, [], just(GroupBy)) -->
+   { service_tag(GroupBy, ServiceTag), !,
+     findall(SN-Brands, artist_albums(SN, Brands), ServiceNameBrands) },
    foldl(report_service_name_brands(ServiceTag), ServiceNameBrands).
-db_list_new(album, [ArtistTag-ArtistCodes], GroupBy) -->
+db_list(album, [], GroupBy) -->
+   { album_reporter(GroupBy, Reporter),
+     setof(B, S^service_brand(S, B), Brands) },
+   foldl(Reporter, Brands).
+db_list(album, [ArtistTag-Artist], GroupBy) -->
    { service_tag(ArtistTag, _),
-     atom_codes(Artist, ArtistCodes),
+     service(S, Artist), ensure_service_schedule(S),
      artist_albums(Artist, Albums),
-     album_reporter(GroupBy, Reporter)
-   },
+     album_reporter(GroupBy, Reporter) },
    foldl(Reporter, Albums).
-db_list_new(albumartist, Filters, nothing) -->
-   {sort(Filters, [album-AlbumCodes, artist-ArtistCodes]),
-    string_codes(Brand, AlbumCodes), atom_codes(Artist, ArtistCodes),
-    service(S, _, Artist), once(service_brand(S, Brand))},
+db_list(albumartist, Filters, nothing) -->
+   { sort(Filters, [album-Album, artist-Artist]),
+     service(S, Artist), once(service_brand(S, Album)) },
    report('AlbumArtist'-Artist).
-db_list_new(Tag, [], nothing) -->
-   {service_tag(Tag, ServiceTag), findall(ServiceName, service(_, _, ServiceName), ServiceNames)},
+db_list(Tag, [], nothing) -->
+   { service_tag(Tag, ServiceTag),
+     findall(ServiceName, service(_, ServiceName), ServiceNames) },
    foldl(report(ServiceTag), ServiceNames).
 
 album_reporter(nothing, report('Album')).
@@ -159,18 +154,19 @@ album_reporter(just(date), report_album_with('Date'-ThisYear)) :-
    get_time(Now), format_time(atom(ThisYear),'%Y',Now).
 
 service_brand(S, B) :- service_entry(S, E), entry_prop(E, parent(_, 'Brand', B)).
-artist_albums(Ar, Als) :- service(S, _, Ar), setof(B, service_brand(S, B), Als).
+artist_albums(Ar, Als) :- service(S, Ar), setof(B, service_brand(S, B), Als).
 report_service_name_brands(ServiceTag, SN-Brands) --> foldl(report_album_with(ServiceTag-SN), Brands).
 report_album_with(TagVal, Album) --> report('Album'-Album), report(TagVal).
 
 % --- common db access for add and lsinfo ---
-ensure_service_schedule(S) :- service_schedule(S, _) -> true; fetch_new_schedule(S).
+ensure_service_schedule(S) :- service_updated(S, _) -> true; fetch_new_schedule(S).
 live_services(Services) :- findall(S-SLN, live_service(S, SLN), Services).
-live_service(S, ServiceName) :- service(S, _, ServiceName).
+live_service(S, ServiceName) :- service(S, ServiceName).
 live_service(resonance, 'Resonance FM').
 live_url(S, URL) :- service_live_url(S, URL).
 live_url(resonance, 'http://stream.resonance.fm:8000/resonance').
 live_service_tags(_-SLN, [file-File, 'Title'-SLN]) :- path_file(['Live Radio', SLN], File).
+entry_date(E, Date) :- entry_prop(E, broadcast(Date)).
 entry_tags(Dir, E, PID) -->
 	[file-File], {entry_prop(E, pid(PID)), path_file([Dir, PID], File)},
    tag(title_and_maybe_album(Dir, PID), E), foldl(maybe, [tag(broadcast, E), tag(availability, E)]),

--- a/prolog/swimpd/database.pl
+++ b/prolog/swimpd/database.pl
@@ -1,13 +1,6 @@
 :- module(database, [is_programme/1, pid_id/2, id_pid/2, lsinfo//1, addid//2, db_update/1, db_image/3,
                      db_stats/1, db_count//1, db_find//2, db_find/3, db_list//3]).
 
-/* <module> BBC database interface for MPD server
-
-   @todo
-      subfolders by week
-      Shelf for keeping programmes
- */
-
 :- use_module(library(memo)).
 :- use_module(library(dcg_core),  [maybe/3]).
 :- use_module(library(listutils), [enumerate/2]).

--- a/prolog/swimpd/database.pl
+++ b/prolog/swimpd/database.pl
@@ -4,7 +4,7 @@
 /* <module> BBC database interface for MPD server
 
    @todo
-      Artist = ? channel? BBC? Folders by brand, by broadcast date
+      subfolders by week
       Shelf for keeping programmes
  */
 

--- a/prolog/swimpd/gst.pl
+++ b/prolog/swimpd/gst.pl
@@ -95,9 +95,16 @@ cue_and_maybe_play(Songs-Pos, P-(_/Dur)) :-
 save_position(Songs-Pos) :-
    nth0(Pos, Songs, song(Id, _, _)),
    (  id_wants_bookmark(Id)
-   -> send("position"), recv(position, PPos), maybe(set_state(position(Id)), PPos)
+   -> send("position"), recv(position, PPos), maybe(save_position(Id), PPos)
    ;  true
    ).
+
+adjust_position(Dur, PPos, Adjusted) :- PPos < Dur-5 -> Adjusted=PPos; Adjusted is Dur - 10.
+save_position(Id, PPos) :-
+   state(duration, Dur),
+   adjust_position(Dur, PPos, Adjusted),
+   debug(gst, 'Saving position at ~w / ~w', [Adjusted, Dur]),
+   set_state(position(Id), Adjusted).
 
 restore_position(Songs-Pos) :-
    nth0(Pos, Songs, song(Id, _, _)),

--- a/prolog/swimpd/protocol.pl
+++ b/prolog/swimpd/protocol.pl
@@ -5,7 +5,7 @@
 :- use_module(library(dcg_pair)).
 :- use_module(tools, [in/2, quoted//2, atom//1, report//1, report//2, parse_head//2, registered/2, thread/2]).
 
-:- multifile command//2, command//3.
+:- multifile command//3.
 
 %! mpd_interactor is det.
 % Run MPD client interaction using the current input and output Prolog streams.
@@ -85,8 +85,8 @@ with_binary_output(S, G) :- setup_call_cleanup(set_stream(S, type(binary)), G, s
 % -- command execution --
 :- meta_predicate do_and_cont(1,+).
 do_and_cont(G, Pending) :- time(call(G, Reply)), reply(Reply), normal_wait(Pending).
-execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail)), !.
-execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail, Binary)), !, call(Binary).
+execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail, nothing)), !.
+execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail, just(G))), !, call(G).
 execute(Ref, Head, _, ack(Ref, err(99, 'Failed on ~s', [Head]))).
 
 % -- notification system ---

--- a/prolog/swimpd/protocol.pl
+++ b/prolog/swimpd/protocol.pl
@@ -5,7 +5,7 @@
 :- use_module(library(dcg_pair)).
 :- use_module(tools, [in/2, quoted//2, atom//1, report//1, report//2, parse_head//2, registered/2, thread/2]).
 
-:- multifile command//3.
+:- multifile command//2, command//3.
 
 %! mpd_interactor is det.
 % Run MPD client interaction using the current input and output Prolog streams.
@@ -84,9 +84,9 @@ with_binary_output(S, G) :- setup_call_cleanup(set_stream(S, type(binary)), G, s
 
 % -- command execution --
 :- meta_predicate do_and_cont(1,+).
-do_and_cont(G, Pending) :- time(call(G, Reply)), reply(Reply), normal_wait(Pending).
-execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail, nothing)), !.
-execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail, just(G))), !, call(G).
+do_and_cont(G, Pending) :- call(G, Reply), reply(Reply), normal_wait(Pending).
+execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail)), !.
+execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail, Binary)), !, call(Binary).
 execute(Ref, Head, _, ack(Ref, err(99, 'Failed on ~s', [Head]))).
 
 % -- notification system ---

--- a/prolog/swimpd/protocol.pl
+++ b/prolog/swimpd/protocol.pl
@@ -1,4 +1,4 @@
-:- module(mpd_protocol, [mpd_interactor/0, notify_all/1, reply_binary/4]).
+:- module(mpd_protocol, [mpd_interactor/0, notify_all/1, reply_binary/4, execute_string/1]).
 
 :- use_module(library(insist), [insist/1]).
 :- use_module(library(dcg_core), [seqmap_with_sep//3]).
@@ -22,6 +22,12 @@ read_command(cmd(Head, Tail)) :-
    read_line_to_codes(current_input, Codes),
    debug(mpd(command), ">> ~s", [Codes]),
    insist(parse_head(Head, Tail, Codes, [])).
+
+execute_string(Cmd) :-
+   string_codes(Cmd, Codes),
+   insist(parse_head(H, T, Codes, [])),
+   execute(0-'', H, T, Reply),
+   reply(Reply).
 
 get_message(M) :- thread_self(Self), thread_get_message(Self, M, [timeout(120)]).
 normal_wait(Pending) :- get_message(M), normal_msg(M, Pending).

--- a/prolog/swimpd/protocol.pl
+++ b/prolog/swimpd/protocol.pl
@@ -11,11 +11,11 @@
 % Run MPD client interaction using the current input and output Prolog streams.
 mpd_interactor :-
    output("OK MPD 0.20.0"), thread_self(Self),
-   setup_call_cleanup(thread_create(client, Id, [at_exit(thread_signal(Self, throw(kill)))]),
-                      catch(transduce(Id), kill, true), cleanup_client(Id)).
+   setup_call_cleanup(thread_create(client, Id, [at_exit(thread_signal(Self, throw(kill_transducer)))]),
+                      catch(transduce(Id), kill_transducer, true), cleanup_client(Id)).
 
 client :- registered(client, normal_wait([])).
-cleanup_client(Id) :- catch(thread_send_message(Id, kill), _, true), thread_join(Id, _).
+cleanup_client(Id) :- catch(thread_send_message(Id, kill_client), _, true), thread_join(Id, _).
 transduce(Q)       :- read_command(Cmd), thread_send_message(Q, Cmd), transduce(Q).
 
 read_command(cmd(Head, Tail)) :-

--- a/prolog/swimpd/protocol.pl
+++ b/prolog/swimpd/protocol.pl
@@ -10,7 +10,7 @@
 %! mpd_interactor is det.
 % Run MPD client interaction using the current input and output Prolog streams.
 mpd_interactor :-
-   output("OK MPD 0.20.0"), thread_self(Self),
+   output("OK MPD 0.21.26"), thread_self(Self),
    setup_call_cleanup(thread_create(client, Id, [at_exit(thread_signal(Self, throw(kill_transducer)))]),
                       catch(transduce(Id), kill_transducer, true), cleanup_client(Id)).
 
@@ -65,7 +65,7 @@ sub_reply(silent).
 sub_reply(list_ok) :- output("list_OK").
 
 reply_phrase(P) :-
-   time(phrase(P, Codes)), format("~s", [Codes]),
+   phrase(P, Codes), format("~s", [Codes]),
    debug(mpd(reply), "<< ~s|", [Codes]).
 
 reply(ok) :- output("OK").
@@ -84,7 +84,7 @@ with_binary_output(S, G) :- setup_call_cleanup(set_stream(S, type(binary)), G, s
 
 % -- command execution --
 :- meta_predicate do_and_cont(1,+).
-do_and_cont(G, Pending) :- call(G, Reply), reply(Reply), normal_wait(Pending).
+do_and_cont(G, Pending) :- time(call(G, Reply)), reply(Reply), normal_wait(Pending).
 execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail)), !.
 execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail, Binary)), !, call(Binary).
 execute(Ref, Head, _, ack(Ref, err(99, 'Failed on ~s', [Head]))).

--- a/prolog/swimpd/protocol.pl
+++ b/prolog/swimpd/protocol.pl
@@ -5,7 +5,7 @@
 :- use_module(library(dcg_pair)).
 :- use_module(tools, [in/2, quoted//2, atom//1, report//2, parse_head//2, registered/2, thread/2]).
 
-:- multifile command//2.
+:- multifile command//2, command//3.
 
 %! mpd_interactor is det.
 % Run MPD client interaction using the current input and output Prolog streams.
@@ -81,6 +81,7 @@ output(R) :-
 :- meta_predicate do_and_cont(1,+).
 do_and_cont(G, Pending) :- call(G, Reply), reply(Reply), normal_wait(Pending).
 execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail)), !.
+execute(_, Head, Tail, ok) :- reply_phrase(command(Head, Tail, _Binary)), !. % FIXME: emit binary here
 execute(Ref, Head, _, ack(Ref, err(99, 'Failed on ~s', [Head]))).
 
 % -- notification system ---

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -19,28 +19,6 @@
                          report//1, report//2, num//1, atom//1, maybe//2, maybe/2, fmaybe/3, fjust/3,
                          thread/2, registered/2, spawn/1, setup_stream/2]).
 
-/* <module> MPD server for BBC radio programmes.
-
-   @todo
-   Core
-      seek, CLP approach?
-      lightweight threads
-      more efficient artist-album-track database view
-
-   Control
-      auto next as well as single (handle stored position correctly too)
-      rewind if playing track where current position is at end
-      Better seekable timeline for radio streams
-      Stop GST player after some time to release audio device
-
-   State management:
-      multiple sessions
-      persistence
-
-   Protocol:
-      clearerror (check error in status?) consume, single, mutliple group
- */
-
 %! mpd_init is det.
 %  Set state of MPD to an empty queue with version 0, volume set to 50%, and start
 %  and db update times to now.

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -69,6 +69,7 @@ revert(V) :-
 term_expansion(command(H,A) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T) --> {phrase(A, T)}, B), R).
 term_expansion(command(H,A,Bin) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T,Bin) --> {phrase(A, T)}, B), R).
 
+% TODO: clearerror (check error in status?) consume, single, mutliple group
 command(commands, []) :-> {findall(C, command(C), Commands)}, foldl(report(command), [close, idle|Commands]).
 command(save,     a(path([Name]))) :-> {save_state(Name)}.
 command(setvol,   a(num(V)))       :-> {upd_and_notify(volume, (\< set(V), \> [mixer]))}.
@@ -98,7 +99,7 @@ command(playlistid,    [])                 :-> reading_state(queue, reading_queu
 command(plchanges,     a(nat(V)))          :-> reading_state(queue, reading_queue(plchanges(V))).
 command(currentsong,   [])                 :-> reading_state(queue, reading_queue(currentsong)).
 command(listplaylists, arb) :-> [].
-command(tagtypes, []) :-> foldl(report(tagtype), ['Artist', 'Album', 'Title', 'Date', 'Comment', 'AvailableUntil']).
+command(tagtypes, []) :-> foldl(report(tagtype), ['Artist', 'Album', 'Title', 'Track', 'Date', 'Comment', 'AvailableUntil']).
 command(outputs,  []) :-> foldl(report, [outputid-0, outputname-'Default output', outputenabled-1]).
 command(status,   []) :-> reading_state(volume, report(volume)), reading_state(queue, report_status).
 command(stats,    []) :-> {stats(Stats)}, foldl(report, Stats).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -66,8 +66,8 @@ revert(V) :-
 % --- command implementations -----
 :- op(1200, xfx, :->).
 :- discontiguous command/1.
-term_expansion(command(H,A) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T) --> {phrase(A, T)}, B), R).
-term_expansion(command(H,A,Bin) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T,Bin) --> {phrase(A, T)}, B), R).
+term_expansion(command(H,A) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T,nothing) --> {phrase(A, T)}, B), R).
+term_expansion(command(H,A,Eff) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T,Eff) --> {phrase(A, T)}, B), R).
 
 command(commands, []) :-> {setof(C, command(C), Commands)}, foldl(report(command), [close, idle|Commands]).
 command(save,     a(path([Name]))) :-> {save_state(Name)}.
@@ -112,8 +112,8 @@ command(searchadd,find_args(Filters)) :-> {db_find(false, Filters, Files), add_m
 command(count,    find_args(Filters)) :-> db_count(Filters). % group not supported
 command(ping,     []) :-> [].
 
-command(albumart,    (a(path(Path)), a(nat(Offset))), swimpd:reply_url_bin(URL, Offset)) :-> {db_image(series, Path, URL)}.
-command(readpicture, (a(path(Path)), a(nat(Offset))), swimpd:reply_url_bin(URL, Offset)) :-> {db_image(episode, Path, URL)}.
+command(albumart,    (a(path(Path)), a(nat(Offset))), just(swimpd:reply_url_bin(URL, Offset))) :-> {db_image(series, Path, URL)}.
+command(readpicture, (a(path(Path)), a(nat(Offset))), just(swimpd:reply_url_bin(URL, Offset))) :-> {db_image(episode, Path, URL)}.
 
 find_args(Filters) --> foldl(tag_value, Filters).
 list_args(album, [artist-Artist], []) --> a("album"), a(atom(Artist)).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -116,8 +116,8 @@ command(albumart,    (a(path(Path)), a(nat(Offset))), swimpd:reply_url_bin(URL, 
 command(readpicture, (a(path(Path)), a(nat(Offset))), swimpd:reply_url_bin(URL, Offset)) :-> {db_image(episode, Path, URL)}.
 
 find_args(Filters) --> foldl(tag_value, Filters).
-list_args(album, [artist-Artist], nothing) --> a("album"), a(atom(Artist)).
-list_args(Tag, Filters, GroupBy) --> a(tag(Tag)), foldl(tag_value, Filters), maybe(group_by, GroupBy).
+list_args(album, [artist-Artist], []) --> a("album"), a(atom(Artist)).
+list_args(Tag, Filters, GroupBy) --> a(tag(Tag)), foldl(tag_value, Filters), foldl(group_by, GroupBy).
 
 reply_url_bin(URL, Offset) :-
    setup_call_cleanup(

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -66,7 +66,7 @@ command(save,     a(path([Name]))) :-> {save_state(Name)}.
 command(setvol,   a(num(V)))       :-> {upd_and_notify(volume, (\< set(V), \> [mixer]))}.
 command(add,      a(path(Path)))   :-> {add_at(nothing, Path, _)}.
 command(addid,    (a(path(Path)), maybe(a(nat), Pos))) :-> {add_at(Pos, Path, just(Id))}, report('Id'-Id).
-command(clear,    [])                       :-> {updating_queue_state(set_songs([]))}.
+% command(clear,    [])                       :-> {updating_queue_state(set_songs([]))}.
 command(delete,   maybe(a(range), R))       :-> {updating_queue_state(delete_range(R, _))}.
 command(deleteid, a(pid(Id)))               :-> {updating_queue_state(delete_id(Id, _))}.
 command(move,     (a(nat(P1)), a(nat(P2)))) :-> {reordering_queue(move(P1, P2))}.

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -38,7 +38,7 @@
       persistence
 
    Protocol:
-      return album and song images
+      clearerror (check error in status?) consume, single, mutliple group
  */
 
 %! mpd_init is det.
@@ -69,7 +69,6 @@ revert(V) :-
 term_expansion(command(H,A) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T) --> {phrase(A, T)}, B), R).
 term_expansion(command(H,A,Bin) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T,Bin) --> {phrase(A, T)}, B), R).
 
-% TODO: clearerror (check error in status?) consume, single, mutliple group
 command(commands, []) :-> {findall(C, command(C), Commands)}, foldl(report(command), [close, idle|Commands]).
 command(save,     a(path([Name]))) :-> {save_state(Name)}.
 command(setvol,   a(num(V)))       :-> {upd_and_notify(volume, (\< set(V), \> [mixer]))}.

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -11,7 +11,7 @@
 :- use_module(library(fileutils), [with_output_to_file/2]).
 :- use_module(bbc(bbc_tools), [enum/2]).
 :- use_module(state,    [set_state/2, upd_state/2, state/2, queue/2, set_queue/2]).
-:- use_module(protocol, [reply_phrase/1, notify_all/1, reply_binary/4]).
+:- use_module(protocol, [notify_all/1, reply_binary/4]).
 :- use_module(database, [is_programme/1, id_pid/2, pid_id/2, lsinfo//1, addid//2, db_update/1, db_count//1,
                          db_find//2, db_find/3, db_list//3, db_image/3, db_stats/1]).
 :- use_module(gst,      [gst_audio_info/2, enact_player_change/3, set_volume/1]).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -69,7 +69,7 @@ revert(V) :-
 term_expansion(command(H,A) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T) --> {phrase(A, T)}, B), R).
 term_expansion(command(H,A,Bin) :-> B, [R, command(H)]) :- dcg_translate_rule((mpd_protocol:command(H,T,Bin) --> {phrase(A, T)}, B), R).
 
-command(commands, []) :-> {findall(C, command(C), Commands)}, foldl(report(command), [close, idle|Commands]).
+command(commands, []) :-> {setof(C, command(C), Commands)}, foldl(report(command), [close, idle|Commands]).
 command(save,     a(path([Name]))) :-> {save_state(Name)}.
 command(setvol,   a(num(V)))       :-> {upd_and_notify(volume, (\< set(V), \> [mixer]))}.
 command(add,      a(path(Path)))   :-> {add_at(nothing, Path, _)}.
@@ -99,6 +99,7 @@ command(plchanges,     a(nat(V)))          :-> reading_state(queue, reading_queu
 command(currentsong,   [])                 :-> reading_state(queue, reading_queue(currentsong)).
 command(listplaylists, arb) :-> [].
 command(tagtypes, []) :-> foldl(report(tagtype), ['Artist', 'Album', 'Title', 'Track', 'Date', 'Comment', 'AvailableUntil']).
+command(tagtypes, foldl(a(atom), [Cmd|Args])) :-> [].
 command(outputs,  []) :-> foldl(report, [outputid-0, outputname-'Default output', outputenabled-1]).
 command(status,   []) :-> reading_state(volume, report(volume)), reading_state(queue, report_status).
 command(stats,    []) :-> {stats(Stats)}, foldl(report, Stats).

--- a/prolog/swimpd/telnetd.pl
+++ b/prolog/swimpd/telnetd.pl
@@ -26,7 +26,7 @@ server_loop(P, Socket, Allow) :-
    tcp_accept(Socket, Slave, Peer),
    debug(mpd(connection), "new connection from ~w", [Peer]),
    tcp_open_socket(Slave, IO),
-   thread_create(call_cleanup(client(P, IO, Peer, Allow), close_peer(Peer, IO)), _, [detached(true)]),
+   thread_create(client(P, IO, Peer, Allow), _, [at_exit(close_peer(Peer, IO)), detached(true)]),
    server_loop(P, Socket, Allow).
 
 close_peer(Peer, IO) :- debug(mpd(connection), 'Closing connection from ~w', [Peer]), close(IO).


### PR DESCRIPTION
This PR introduces a new way to read radio schedules from the BBC now that the XML feeds have been resricted (see  https://www.bbc.co.uk/sounds/help/questions/recent-changes-to-bbc-sounds/distribution-changes).

It also adds support for 'Artist' and 'Album' views, using the radio station as a proxy for the 'Artist' and radio programme 'brand' or series as the 'Album' name. The _swimpd_ server now support a subset of `list`, `find` and `findadd` queries (not in a nice way - that will come later). It also supports `albumart` by streaming the 'brand' image data from the BBC directly to the MPD client. This does not work with all clients but it does work with M.A.L.P. if you set up M.A.L.P. correctly.

There are numerous fixes and enhancements. For example, when reaching the end of a stream, instead of storing the current position at the very end, which makes it impossible to listen to the programme again, the position is adjusted back a few seconds so (a) you can tell you listened to the whole programme but (b) you have time to react and rewind to the beginning if you want to listen to it again.

It also adds support for the `single` and `consume` commands. `single` is handled correctly, but `consume` is not yet implemented. 

`bbc_db` now has support for getting the track list for a programme, which will be useful for implementing some nice new functionality in a later version.

Fixes:
- Handle gzip content format on versions of SWIPL (7.?) where loading the `zlib` does not automatically register needed HTTP hook.
- Fix TCP stream leak on an older SWIPL (7.?) which does not seem to execute the 'cleanup' of `call_cleanup` in the client service thread. Putting the clean up in the `at_exit` options seems to fix it.