### PR TITLE
Persistent state

### DIFF
--- a/prolog/swimpd/database.pl
+++ b/prolog/swimpd/database.pl
@@ -1,4 +1,4 @@
-%% Tyoes used in this module:
+%% Types used in this module:
 %  pid   ~ a BBC programme identifier (for a programme or a service)
 %  id    ~ a local numeric identifier, valid only during one running instance of SWIPD
 %  mpd_filter         ~ a spec for finding items in the database.
@@ -75,7 +75,7 @@ lsinfo([Dir]) --> {directory(Dir, Items)}, foldl(programme(Dir), Items).
 directory('In Progress', Items) :-
    findall(E, (state(position(PID), _), once(pid_entry(_, PID, E))), Items).
 directory(ServiceName, SortedItems) :-
-	service(S, ServiceName),
+   service(S, ServiceName),
    ensure_service_schedule(S),
    findall(E, service_entry(S, E), Items),
    sort_by(entry_sortkey, Items, SortedItems).
@@ -89,8 +89,8 @@ service_dir(S-Name) --> report(directory-Name), maybe(service_updated(S)).
 service_updated(S) --> {service_updated(S, Updated)}, report('Last-Modified'-Updated).
 
 programme(Dir, E) -->
-	{insist(entry_tags(Dir, E, PID, Tags, [])), pid_id(PID, Id)},
-	foldl(report, Tags), report('Id'-Id).
+   {insist(entry_tags(Dir, E, PID, Tags, [])), pid_id(PID, Id)},
+   foldl(report, Tags), report('Id'-Id).
 
 % --- list by tag ---
 service_tag(artist, 'Artist').
@@ -116,9 +116,9 @@ db_count(Filters) -->
 entries_tracks(Es, Tracks) :- call(enumerate * sort_by(entry_date), Es, Tracks).
 track_path(_-E, [SN, PID]) :- maplist(entry_prop(E), [pid(PID), service(SN)]).
 found_track(TrackNo-E) -->
-	{ entry_prop(E, service(ServiceName)),
+   { entry_prop(E, service(ServiceName)),
      insist(entry_tags(ServiceName, E, _PID, Tags, [])) },
-	foldl(report, Tags), report('Track'-TrackNo).
+   foldl(report, Tags), report('Track'-TrackNo).
 
 find(Filters, [Track]) :-
    select(track-TrackAtom, Filters, FiltersRem), atom_number(TrackAtom, TrackNo),
@@ -191,7 +191,7 @@ entry_date(E, Date) :- entry_prop(E, broadcast(Date)).
 entry_tags(Dir, E, PID) -->
    { maplist(entry_prop(E), [pid(PID), synopsis(Syn), duration(Dur)]),
      path_file([Dir, PID], File), to_one_line(Syn, Syn1) },
-	[file-File, 'Comment'-Syn1, duration-Dur],
+   [file-File, 'Comment'-Syn1, duration-Dur],
    tag(title_and_maybe_album(Dir, PID), E),
    foldl(maybe, [tag(service, E), tag(broadcast, E), tag(availability, E)]).
 

--- a/prolog/swimpd/gst.pl
+++ b/prolog/swimpd/gst.pl
@@ -96,8 +96,8 @@ enact_ps_change(Songs1-Songs2, ps(Pos1, Sl1), ps(Pos2, Sl2)) :-
 enact_slave_change(_,          nothing, nothing) :- !.
 enact_slave_change(SongsPos-_, just(S), nothing) :- !, stop_if_playing(SongsPos, S).
 enact_slave_change(_-SongsPos, nothing, just(S-Au)) :- !, cue_and_maybe_play(SongsPos, S-Au).
-enact_slave_change(_,          just(S1-_), just(S2-_)) :-
-   (  S1-S2 = play-pause -> send("pause")
+enact_slave_change(_-SongsPos, just(S1-_), just(S2-_)) :-
+   (  S1-S2 = play-pause -> send("pause"), save_position(SongsPos)
    ;  S1-S2 = pause-play -> send("play")
    ;  true
    ).

--- a/prolog/swimpd/gst.pl
+++ b/prolog/swimpd/gst.pl
@@ -6,7 +6,7 @@
 :- use_module(library(dcg_codes), [fmt//2]).
 :- use_module(library(data/pair), [ffst/3]).
 :- use_module(library(snobol), [break//1, arb//0, any//1]).
-:- use_module(state, [state/2, set_state/2, vstate/2, set_vstate/2, rm_vstate/1]).
+:- use_module(state, [state/2, set_states/2, vstate/2, set_vstate/2, rm_vstate/1]).
 :- use_module(tools,  [forever/1, parse_head//2, num//1, nat//1, fmaybe/3, maybe/2, registered/2, setup_stream/2, thread/2]).
 
 :- multifile notify_eos/0, id_wants_bookmark/1.
@@ -24,17 +24,11 @@ gst_reader_thread(_-(In-Out)) :-
    registered(gst(In), gst_reader(Out)).
 
 gst_reader(Out) :-
-   state(volume, V), set_volume(V),
-   ( state(player, Player) -> state(queue, _-Songs) % factorised
-   ; state(queue, (_-Songs)-Player) -> true         % intermediate
-   ; state(queue, _-(Songs-Player))                 % old
-   ),
-   fmaybe(pause_player, Player, PausedPlayer),
-   debug(gst, "Restoring player as ~w", [PausedPlayer]),
-   enact_player_change([]-Songs, nothing, PausedPlayer),
+   maplist(state, [volume, player, queue], [V, Player, _-Songs]),
+   set_volume(V), enact_player_change([]-Songs, nothing, Player),
    thread_self(Self), gst_read_next(Self, Out).
 
-pause_player(ps(Pos, Sl1), ps(Pos, Sl2)) :- fmaybe(ffst(set(pause)), Sl1, Sl2).
+% pause_player(ps(Pos, Sl1), ps(Pos, Sl2)) :- fmaybe(ffst(set(pause)), Sl1, Sl2).
 gst_read_next(Self, Out) :- read_line_to_codes(Out, Codes), gst_handle(Codes, Self, Out).
 gst_handle(end_of_file, _, _) :- !, debug(gst, 'End of stream from gst', []).
 gst_handle(Codes, Self, Out) :-
@@ -126,7 +120,7 @@ save_position(Id, PPos) :-
    vstate(duration, Dur),
    adjust_position(Dur, PPos, Adjusted),
    debug(gst, 'Saving position at ~w / ~w', [Adjusted, Dur]),
-   set_state(position(Id), Adjusted).
+   set_states(position(Id), Adjusted).
 
 restore_position(Songs-Pos) :-
    nth0(Pos, Songs, song(Id, _, _)),

--- a/prolog/swimpd/gst.pl
+++ b/prolog/swimpd/gst.pl
@@ -25,8 +25,9 @@ gst_reader_thread(_-(In-Out)) :-
 
 gst_reader(Out) :-
    state(volume, V), set_volume(V),
-   ( state(player, Player) -> state(queue, _-Songs)
-   ; state(queue, _-(Songs-Player))
+   ( state(player, Player) -> state(queue, _-Songs) % factorised
+   ; state(queue, (_-Songs)-Player) -> true         % intermediate
+   ; state(queue, _-(Songs-Player))                 % old
    ),
    fmaybe(pause_player, Player, PausedPlayer),
    debug(gst, "Restoring player as ~w", [PausedPlayer]),

--- a/prolog/swimpd/gst.pl
+++ b/prolog/swimpd/gst.pl
@@ -25,7 +25,9 @@ gst_reader_thread(_-(In-Out)) :-
 
 gst_reader(Out) :-
    state(volume, V), set_volume(V),
-   state(queue, _-(Songs-Player)),
+   ( state(player, Player) -> state(queue, _-Songs)
+   ; state(queue, _-(Songs-Player))
+   ),
    fmaybe(pause_player, Player, PausedPlayer),
    debug(gst, "Restoring player as ~w", [PausedPlayer]),
    enact_player_change([]-Songs, nothing, PausedPlayer),

--- a/prolog/swimpd/state.pl
+++ b/prolog/swimpd/state.pl
@@ -1,11 +1,12 @@
-:- module(mpd_state, [attach/1, init_state/2, upd_states/2, set_states/2, state/2, states/2,
+:- module(mpd_state, [excl/1, attach/1, init_state/2, upd_states/2, set_states/2, state/2, states/2,
                       set_vstate/2, rm_vstate/1, vstate/2,  version_queue/2, add_queue/2]).
 :- use_module(library(persistency)).
 
 :- persistent state(term, term).
 :- dynamic vstate/2, version_queue/2.
-:- meta_predicate upd_states(+,2).
+:- meta_predicate excl(0), upd_states(+,2).
 
+excl(G)          :- with_mutex(swimpd, G).
 attach(DBFile)   :- db_attach(DBFile, []).
 init_state(K, V) :- state(K, _) -> true; assert_state(K, V).
 upd_states(K, P) :- states(K, S1), call(P, S1, S2), set_states(K, S2).

--- a/prolog/swimpd/state.pl
+++ b/prolog/swimpd/state.pl
@@ -1,22 +1,20 @@
-:- module(mpd_state, [init_state/2, upd_state/2, set_state/2, state/2,
+:- module(mpd_state, [attach/1, init_state/2, upd_states/2, set_states/2, state/2, states/2,
                       set_vstate/2, rm_vstate/1, vstate/2,  version_queue/2, add_queue/2]).
 :- use_module(library(persistency)).
 
-
-% state = pair(pair(integer, pair(list(song), maybe(play_state))), dict).
-% play_state ---> ps(natural, maybe(pair(pause_state, au_state))).
-% au_state   ---> au(duration, elapsed, bitrate, format).
-% pause_state ---> play; pause.
-
 :- persistent state(term, term).
 :- dynamic vstate/2, version_queue/2.
-:- meta_predicate upd_state(+,2).
+:- meta_predicate upd_states(+,2).
 
-:- db_attach('current_state.db', []).
+attach(DBFile)   :- db_attach(DBFile, []).
+init_state(K, V) :- state(K, _) -> true; assert_state(K, V).
+upd_states(K, P) :- states(K, S1), call(P, S1, S2), set_states(K, S2).
 
-set_state(Key, Val)  :- retractall_state(Key, _), assert_state(Key, Val).
-init_state(Key, Val) :- state(Key, _) -> true; assert_state(Key, Val).
-upd_state(K, P)      :- with_mutex(swimpd, (state(K, S1), call(P, S1, S2), set_state(K, S2))).
+states(K1-K2, V1-V2) :- !, states(K1,V1), states(K2,V2).
+states(K,V)          :- state(K,V).
+
+set_states(K1-K2, V1-V2) :- set_states(K1,V1), set_states(K2,V2).
+set_states(K,V)          :- debug(state, "Setting state ~w to ~w", [K,V]), retractall_state(K, _), assert_state(K, V).
 
 % volatile state
 set_vstate(Key, Val) :- retractall(vstate(Key, _)), assert(vstate(Key, Val)).

--- a/prolog/swimpd/state.pl
+++ b/prolog/swimpd/state.pl
@@ -1,4 +1,5 @@
-:- module(mpd_state, [init_state/2, rm_state/1, upd_state/2, set_state/2, state/2, queue/2, set_queue/2]).
+:- module(mpd_state, [init_state/2, upd_state/2, set_state/2, state/2,
+                      set_vstate/2, rm_vstate/1, vstate/2,  version_queue/2, add_queue/2]).
 :- use_module(library(persistency)).
 
 
@@ -8,13 +9,17 @@
 % pause_state ---> play; pause.
 
 :- persistent state(term, term).
-:- dynamic queue/2.
+:- dynamic vstate/2, version_queue/2.
 :- meta_predicate upd_state(+,2).
 
 :- db_attach('current_state.db', []).
 
 set_state(Key, Val)  :- retractall_state(Key, _), assert_state(Key, Val).
-rm_state(Key)        :- retractall_state(Key, _).
 init_state(Key, Val) :- state(Key, _) -> true; assert_state(Key, Val).
 upd_state(K, P)      :- with_mutex(swimpd, (state(K, S1), call(P, S1, S2), set_state(K, S2))).
-set_queue(V, Songs)  :- assert(queue(V, Songs)).
+
+% volatile state
+set_vstate(Key, Val) :- retractall(vstate(Key, _)), assert(vstate(Key, Val)).
+rm_vstate(Key)       :- retractall(vstate(Key, _)).
+
+add_queue(Version, Songs)  :- assert(version_queue(Version, Songs)).

--- a/prolog/swimpd/state.pl
+++ b/prolog/swimpd/state.pl
@@ -1,13 +1,20 @@
-:- module(mpd_state, [rm_state/1, upd_state/2, set_state/2, state/2, queue/2, set_queue/2]).
+:- module(mpd_state, [init_state/2, rm_state/1, upd_state/2, set_state/2, state/2, queue/2, set_queue/2]).
+:- use_module(library(persistency)).
+
 
 % state = pair(pair(integer, pair(list(song), maybe(play_state))), dict).
 % play_state ---> ps(natural, maybe(pair(pause_state, au_state))).
 % au_state   ---> au(duration, elapsed, bitrate, format).
 % pause_state ---> play; pause.
 
-:- dynamic state/2, queue/2.
+:- persistent state(term, term).
+:- dynamic queue/2.
 :- meta_predicate upd_state(+,2).
-set_state(Key, Val) :- retractall(state(Key, _)), assert(state(Key, Val)).
-rm_state(Key)       :- retractall(state(Key, _)).
-upd_state(K, P)     :- with_mutex(swimpd, (state(K, S1), call(P, S1, S2), set_state(K, S2))).
-set_queue(V, Songs) :- assert(queue(V, Songs)).
+
+:- db_attach('current_state.db', []).
+
+set_state(Key, Val)  :- retractall_state(Key, _), assert_state(Key, Val).
+rm_state(Key)        :- retractall_state(Key, _).
+init_state(Key, Val) :- state(Key, _) -> true; assert_state(Key, Val).
+upd_state(K, P)      :- with_mutex(swimpd, (state(K, S1), call(P, S1, S2), set_state(K, S2))).
+set_queue(V, Songs)  :- assert(queue(V, Songs)).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -75,6 +75,12 @@ restore_state(Filename) :-
    upd_and_notify(volume, (set(Vol) <\> [mixer])),
    updating_queue_state(set(Songs-Player) <\> [player]).
 
+   % forall((member(state(K,V), Terms), call(Include, K)), restore_key(K,  V)).
+% restore_key(Key,    V) :- member(Key, [single, consume]), upd_and_notify_option(Key-V).
+% restore_key(volume, V) :- upd_and_notify(volume, (set(V) <\> [mixer])).
+% restore_key(queue,  _-Q) :- updating_queue_state(set(Q) <\> [player]).
+% restore_key(position(Id), P) :- set_state(position(Id), P).
+
 restore_queue_version(V) :- version_queue(V, Songs), updating_queue_state(set_songs(Songs)).
 
 % --- command implementations -----

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -29,7 +29,6 @@
       review process synch and comms, see eg Erlang approach
 
    Control
-      auto next as well as single (handle stored position correctly too)
       rewind if playing track where current position is at end
       Better seekable timeline for radio streams
       Stop GST player after some time to release audio device
@@ -50,6 +49,9 @@
       Use tracklist for cool stuff:
       - seek to nth/prev/next track
       - query current track info
+
+   Playlists
+      More playlist protocol: listing and loading
  */
 
 %! mpd_init is det.
@@ -143,9 +145,10 @@ reply_url_bin(URL, Offset) :-
 upd_and_notify(K, P) :- upd_state(K, upd_and_enact(K, P, Changes)), sort(Changes, Changed), notify_all(Changed).
 upd_and_enact(K, P, Changes, S1, S2) :- call_dcg(P, S1-Changes, S2-[]), enact(K, Changes, S1, S2), !.
 
-upd_and_notify_option(K-V) :- upd_and_notify(K, (set(V) <\> [options])).
-updating_play_state(Action) :- upd_and_notify(queue, (\< fsnd(Action), \> [player])).
+upd_and_notify_option(Key-V) :- upd_and_notify(Key,   set(V) <\> [options]).
+updating_play_state(Action)  :- upd_and_notify(queue, fplay_state(Action) <\> [player]).
 updating_queue_state(Action) :- upd_and_notify(queue, (fqueue(Action,V,Songs), \> [playlist])), add_queue(V, Songs).
+fplay_state(Action, V-Q1, V-Q2) :- call(Action, Q1, Q2).
 fqueue(P, V2, Songs, (V1-Q1)-C1, (V2-Q2)-C2) :- call(P, Q1-C1, Q2-C2), succ(V1, V2), Q2 = Songs-_.
 
 reordering_queue(Action) :- updating_queue_state(\< preserving_player(Action)).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -22,9 +22,6 @@
 /* <module> MPD server for BBC radio programmes.
 
    @todo
-   Reconsider state:
-      factorise queue - version, song list, player state for better use of persistency
-      version_queue/2 -> version tree, undo etc.
    Core
       seek, CLP approach?
       lightweight threads
@@ -38,8 +35,11 @@
       Stop GST player after some time to release audio device
 
    State management:
+      factorise queue - version, song list, player state for better use of persistency
+      version_queue/2 -> version tree, undo etc. (plchanges?)
       multiple sessions
       persistence
+      selective restore - everything vs just queue.
 
    Protocol:
       clearerror (check error in status?) consume, mutliple group

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -75,12 +75,6 @@ restore_state(Filename) :-
    upd_and_notify(volume, (set(Vol) <\> [mixer])),
    updating_queue_state(set(Songs-Player) <\> [player]).
 
-   % forall((member(state(K,V), Terms), call(Include, K)), restore_key(K,  V)).
-% restore_key(Key,    V) :- member(Key, [single, consume]), upd_and_notify_option(Key-V).
-% restore_key(volume, V) :- upd_and_notify(volume, (set(V) <\> [mixer])).
-% restore_key(queue,  _-Q) :- updating_queue_state(set(Q) <\> [player]).
-% restore_key(position(Id), P) :- set_state(position(Id), P).
-
 restore_queue_version(V) :- version_queue(V, Songs), updating_queue_state(set_songs(Songs)).
 
 % --- command implementations -----

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -193,9 +193,8 @@ insert_at(Pos, P, Songs1, Songs2) :-
    rep(Pos, copy, Songs1-Songs2, Suffix-PrefixT),
    phrase(P, PrefixT, Suffix).
 
-set_songs(Songs) --> \< trans(Q, (Songs-nothing)), \> player_if_queue_playing(Q).
-player_if_queue_playing(_-PS) --> maybe(player_if_playstate_playing, PS).
-player_if_playstate_playing(_) --> [player].
+set_songs(Songs) --> trans(_-Player, (Songs-nothing)) <\> maybe(player_if_playing, Player).
+player_if_playing(_) --> [player].
 
 delete_range(nothing, Id) --> \< get(_-just(ps(Pos, _))), delete(Pos, Id).
 delete_range(just(M:N), Ids) --> {numlist(M, N, Is), reverse(Is, [_|Js])}, foldl(delete, Js, Ids).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -162,8 +162,8 @@ preserving_player(P) --> (P // trans(Songs1, Songs2)) <\> fmaybe(update_pos(Song
 report_state(K) --> reading_state(K, report(K)).
 uptime(T) :- get_time(Now), vstate(start_time, Then), T is integer(Now - Then).
 stats([uptime-T, db_update-DD|DBStats]) :- uptime(T), vstate(dbtime, D), round(D,DD), db_stats(DBStats).
-update_db(Path) --> {flag(update, JOB, JOB+1), spawn(update_and_notify(Path))}, report(updating_db-JOB). % FIXME: put JOB in state
-update_and_notify(Path) :- db_update(Path), get_time(Now), set_vstate(dbtime, Now), notify_all([database]).
+update_db(Path) --> {flag(update, JOB, JOB+1), spawn(update_db_and_notify(Path))}, report(updating_db-JOB). % FIXME: put JOB in state
+update_db_and_notify(Path) :- db_update(Path), get_time(Now), set_vstate(dbtime, Now), notify_all([database]).
 
 enact(volume, [], _, _) :- !, debug(mpd(alert), "UNEXPECTED ENACT VOLUME CLAUSE", []).
 enact(volume, [mixer], _, V) :- !, set_volume(V).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -61,7 +61,7 @@ mpd_init :-
    maplist(set_vstate, [start_time, dbtime], [Now, Now]),
    retractall(version_queue(_,_)), assert(version_queue(0, [])).
 
-save_state(Fn) :- with_output_to_file(Fn, listing(mpd_state:state)).
+save_state(Filename) :- with_output_to_file(Filename, listing(mpd_state:state)).
 
 :- meta_predicate restore_state(2).
 restore_state(State) :-

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -69,7 +69,10 @@ restore_state(Filename) :-
    read_file_to_terms(Filename, Terms, []),
    findall(K-V, member(state(K,V), Terms), Pairs),
    call(ord_list_to_assoc * sort, Pairs, Assoc),
-   maplist(flip(get_assoc, Assoc), [consume, single, volume, queue], [Consume, Single, Vol, _-(Songs-Player)]),
+   maplist(flip(get_assoc, Assoc), [consume, single, volume], [Consume, Single, Vol]),
+   ( get_assoc(player, Assoc, Player) -> get_assoc(queue, _-Songs)
+   ; get_assoc(queue, _-(Songs-Player))
+   ),
    forall(member(position(Id)-PPos, Pairs), set_state(position(Id), PPos)),
    maplist(upd_and_notify_option, [single-Single, consume-Consume]),
    upd_and_notify(volume, (set(Vol) <\> [mixer])),

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -1,4 +1,4 @@
-:- module(swimpd, [mpd_init/0, restore_state/1, save_state/1, save_state/0]).
+:- module(swimpd, [mpd_init/0, restore_state/1, save_state/1]).
 
 :- use_module(library(http/http_open)).
 :- use_module(library(dcg_core)).
@@ -57,7 +57,6 @@ mpd_init :-
    maplist(init_state, [start_time, dbtime, volume, queue, consume, single], [Now, Now, 50, 0-([]-nothing), 0, 1]),
    retractall(queue(_,_)), assert(queue(0, [])).
 
-save_state :- get_time(Now), format_time(string(Fn), "state-%FT%T.pl", Now), save_state(Fn).
 save_state(Fn) :- with_output_to_file(Fn, listing(mpd_state:state)).
 
 :- meta_predicate restore_state(2).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -10,7 +10,7 @@
 :- use_module(library(callutils), [true2/2]).
 :- use_module(library(fileutils), [with_output_to_file/2]).
 :- use_module(bbc(bbc_tools), [enum/2]).
-:- use_module(state,    [set_state/2, upd_state/2, state/2, queue/2, set_queue/2]).
+:- use_module(state,    [init_state/2, set_state/2, upd_state/2, state/2, queue/2, set_queue/2]).
 :- use_module(protocol, [notify_all/1, reply_binary/4]).
 :- use_module(database, [is_programme/1, id_pid/2, pid_id/2, pid_tracks/2, lsinfo//1, addid//2, db_update/1,
                          db_count//1, db_find//2, db_find/3, db_list//3, db_image/3, db_stats/1]).
@@ -54,7 +54,7 @@
 %  and db update times to now.
 mpd_init :-
    get_time(Now), flag(update, _, 1),
-   maplist(set_state, [start_time, dbtime, volume, queue, consume, single], [Now, Now, 50, 0-([]-nothing), 0, 1]),
+   maplist(init_state, [start_time, dbtime, volume, queue, consume, single], [Now, Now, 50, 0-([]-nothing), 0, 1]),
    retractall(queue(_,_)), assert(queue(0, [])).
 
 save_state :- get_time(Now), format_time(string(Fn), "state-%FT%T.pl", Now), save_state(Fn).

--- a/prolog/swimpd/swimpd.pl
+++ b/prolog/swimpd/swimpd.pl
@@ -22,6 +22,9 @@
 /* <module> MPD server for BBC radio programmes.
 
    @todo
+   Reconsider state:
+      factorise queue - version, song list, player state for better use of persistency
+      version_queue/2 -> version tree, undo etc.
    Core
       seek, CLP approach?
       lightweight threads

--- a/swimpd
+++ b/swimpd
@@ -15,12 +15,16 @@ user:file_search_path(bbc, 'prolog').
 local(ip(127,0,0,1)).
 local(ip(192,168,1,_)).
 
-%! start_mpd(Port, Options) is det.
-%  Start BBC MPD server as a detached thread with alias =|mpd_server|=.
-%  See telnet_server/3 for description of Port and Options parameters.
-start_mpd(Port, Options) :- thread_create(telnet_server(mpd_interactor, Port, Options), _, [detached(true), alias(mpd_server)]).
+:- meta_predicate detached(+,0).
+detached(Alias, Goal) :- thread_create(Goal, _, [detached(true), alias(Alias)]), confirm_on_halt.
+mpd_server(Port, Options) :- telnet_server(mpd_interactor, Port, Options).
 
-start([A1]) :- atom_number(A1, Port), start_mpd(Port, [allow(local)]), start_gst_thread.
-main :- current_prolog_flag(argv, Argv), attach('current_state.db'), mpd_init, start(Argv), confirm_on_halt. 
-:- (flag(swimpd_load_count, 0, 1) -> main; true).
+runner(interactive, detached(mpd_server)).
+runner(foreground,  call).
+
+main([State, PortAtom, Mode]) :- 
+   atom_number(PortAtom, Port), runner(Mode, Runner), attach(State), mpd_init, 
+   start_gst_thread, call(Runner, mpd_server(Port, [allow(local)])).
+
+:- (flag(swimpd_load_count, 0, 1) -> current_prolog_flag(argv, ArgV), main(ArgV); true).
 % vim: ft=prolog

--- a/swimpd
+++ b/swimpd
@@ -7,7 +7,7 @@ user:file_search_path(bbc, 'prolog').
 :- use_module(prolog/swimpd/telnetd,  [telnet_server/3]).
 :- use_module(prolog/swimpd/protocol, [mpd_interactor/0]).
 :- use_module(prolog/swimpd/gst,      [start_gst_thread/0]).
-:- use_module(prolog/swimpd/swimpd,   [mpd_init/0, restore_state/1, save_state/0]).
+:- use_module(prolog/swimpd/swimpd,   [mpd_init/0, restore_state/1, save_state/1]).
 :- use_module(library(fileutils), [with_output_to_file/2]).
 :- use_module(library(rcutils)).
 

--- a/swimpd
+++ b/swimpd
@@ -20,6 +20,6 @@ local(ip(192,168,1,_)).
 start_mpd(Port, Options) :- thread_create(telnet_server(mpd_interactor, Port, Options), _, [detached(true), alias(mpd_server)]).
 
 start([A1]) :- atom_number(A1, Port), start_mpd(Port, [allow(local)]), start_gst_thread.
-main :- current_prolog_flag(argv, Argv), mpd_init, start(Argv), confirm_on_halt, at_halt(save_state).
+main :- current_prolog_flag(argv, Argv), mpd_init, start(Argv), confirm_on_halt. 
 :- (flag(swimpd_load_count, 0, 1) -> main; true).
 % vim: ft=prolog

--- a/swimpd
+++ b/swimpd
@@ -7,6 +7,7 @@ user:file_search_path(bbc, 'prolog').
 :- use_module(prolog/swimpd/telnetd,  [telnet_server/3]).
 :- use_module(prolog/swimpd/protocol, [mpd_interactor/0]).
 :- use_module(prolog/swimpd/gst,      [start_gst_thread/0]).
+:- use_module(prolog/swimpd/state,    [attach/1]).
 :- use_module(prolog/swimpd/swimpd,   [mpd_init/0, restore_state/1, save_state/1]).
 :- use_module(library(fileutils), [with_output_to_file/2]).
 :- use_module(library(rcutils)).
@@ -20,6 +21,6 @@ local(ip(192,168,1,_)).
 start_mpd(Port, Options) :- thread_create(telnet_server(mpd_interactor, Port, Options), _, [detached(true), alias(mpd_server)]).
 
 start([A1]) :- atom_number(A1, Port), start_mpd(Port, [allow(local)]), start_gst_thread.
-main :- current_prolog_flag(argv, Argv), mpd_init, start(Argv), confirm_on_halt. 
+main :- current_prolog_flag(argv, Argv), attach('current_state.db'), mpd_init, start(Argv), confirm_on_halt. 
 :- (flag(swimpd_load_count, 0, 1) -> main; true).
 % vim: ft=prolog


### PR DESCRIPTION
Uses the persistency module to make the state/2 predicate persistent.
Some state moved out to separate volatile vstate/2.
The player state is factorised out of old `queue` state so that the persistent journal is not bloated with unecessary updates to the playlist.
Player is state is fully restored on startup (including actual playing)
Startup script now takes a path to the persistent state journal and a new 'mode' parameter as we inch towards turning swimpd into a proper service.